### PR TITLE
Updated wincred vendor & fixed Windows build

### DIFF
--- a/vendor/github.com/danieljoos/wincred/conversion.go
+++ b/vendor/github.com/danieljoos/wincred/conversion.go
@@ -1,7 +1,6 @@
 package wincred
 
 import (
-	"C"
 	"encoding/binary"
 	"reflect"
 	"syscall"
@@ -9,6 +8,8 @@ import (
 	"unicode/utf16"
 	"unsafe"
 )
+
+var nullPointer = unsafe.Pointer(uintptr(0))
 
 // Create a Go string using a pointer to a zero-terminated UTF 16 encoded string.
 // See github.com/AllenDang/w32
@@ -36,8 +37,22 @@ func utf16ToByte(wstr []uint16) (result []byte) {
 	return
 }
 
+// Copies the given C byte array to a Go byte array (see `C.GoBytes`)
+func goBytes(src unsafe.Pointer, len uint32) []byte {
+	if src == nullPointer {
+		return []byte{}
+	}
+	slice := (*[1 << 30]byte)(src)[0:len]
+	rv := make([]byte, len)
+	copy(rv, slice)
+	return rv[:]
+}
+
 // Convert the given CREDENTIAL struct to a more usable structure
 func nativeToCredential(cred *nativeCREDENTIAL) (result *Credential) {
+	if unsafe.Pointer(cred) == nullPointer {
+		return nil
+	}
 	result = new(Credential)
 	result.Comment = utf16PtrToString(cred.Comment)
 	result.TargetName = utf16PtrToString(cred.TargetName)
@@ -45,7 +60,7 @@ func nativeToCredential(cred *nativeCREDENTIAL) (result *Credential) {
 	result.UserName = utf16PtrToString(cred.UserName)
 	result.LastWritten = time.Unix(0, cred.LastWritten.Nanoseconds())
 	result.Persist = CredentialPersistence(cred.Persist)
-	result.CredentialBlob = C.GoBytes(unsafe.Pointer(cred.CredentialBlob), C.int(cred.CredentialBlobSize))
+	result.CredentialBlob = goBytes(unsafe.Pointer(cred.CredentialBlob), cred.CredentialBlobSize)
 	result.Attributes = make([]CredentialAttribute, cred.AttributeCount)
 	attrSliceHeader := reflect.SliceHeader{
 		Data: cred.Attributes,
@@ -56,7 +71,7 @@ func nativeToCredential(cred *nativeCREDENTIAL) (result *Credential) {
 	for i, attr := range attrSlice {
 		resultAttr := &result.Attributes[i]
 		resultAttr.Keyword = utf16PtrToString(attr.Keyword)
-		resultAttr.Value = C.GoBytes(unsafe.Pointer(attr.Value), C.int(attr.ValueSize))
+		resultAttr.Value = goBytes(unsafe.Pointer(attr.Value), attr.ValueSize)
 	}
 	return result
 }
@@ -64,6 +79,9 @@ func nativeToCredential(cred *nativeCREDENTIAL) (result *Credential) {
 // Convert the given Credential object back to a CREDENTIAL struct, which can be used for calling the
 // Windows APIs
 func nativeFromCredential(cred *Credential) (result *nativeCREDENTIAL) {
+	if cred == nil {
+		return nil
+	}
 	result = new(nativeCREDENTIAL)
 	result.Flags = 0
 	result.Type = 0

--- a/vendor/github.com/danieljoos/wincred/native.go
+++ b/vendor/github.com/danieljoos/wincred/native.go
@@ -1,7 +1,6 @@
 package wincred
 
 import (
-	"C"
 	"syscall"
 	"unsafe"
 )
@@ -9,12 +8,17 @@ import (
 var (
 	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")
 
-	procCredRead      = modadvapi32.NewProc("CredReadW")
-	procCredWrite     = modadvapi32.NewProc("CredWriteW")
-	procCredDelete    = modadvapi32.NewProc("CredDeleteW")
-	procCredFree      = modadvapi32.NewProc("CredFree")
-	procCredEnumerate = modadvapi32.NewProc("CredEnumerateW")
+	procCredRead      proc = modadvapi32.NewProc("CredReadW")
+	procCredWrite     proc = modadvapi32.NewProc("CredWriteW")
+	procCredDelete    proc = modadvapi32.NewProc("CredDeleteW")
+	procCredFree      proc = modadvapi32.NewProc("CredFree")
+	procCredEnumerate proc = modadvapi32.NewProc("CredEnumerateW")
 )
+
+// Interface for syscall.Proc: helps testing
+type proc interface {
+	Call(a ...uintptr) (r1, r2 uintptr, lastErr error)
+}
 
 // http://msdn.microsoft.com/en-us/library/windows/desktop/aa374788(v=vs.85).aspx
 type nativeCREDENTIAL struct {
@@ -50,6 +54,8 @@ const (
 	naCRED_TYPE_DOMAIN_VISIBLE_PASSWORD nativeCRED_TYPE = 0x4
 	naCRED_TYPE_GENERIC_CERTIFICATE     nativeCRED_TYPE = 0x5
 	naCRED_TYPE_DOMAIN_EXTENDED         nativeCRED_TYPE = 0x6
+
+	naERROR_NOT_FOUND = "Element not found."
 )
 
 // http://msdn.microsoft.com/en-us/library/windows/desktop/aa374804(v=vs.85).aspx

--- a/vendor/github.com/danieljoos/wincred/wincred.go
+++ b/vendor/github.com/danieljoos/wincred/wincred.go
@@ -70,5 +70,11 @@ func (t *DomainPassword) SetPassword(pw string) {
 
 // List the contents of the Credentials store
 func List() ([]*Credential, error) {
-	return nativeCredEnumerate("", true)
+	creds, err := nativeCredEnumerate("", true)
+	if err != nil && err.Error() == naERROR_NOT_FOUND {
+		// Ignore ERROR_NOT_FOUND and return an empty list instead
+		creds = []*Credential{}
+		err = nil
+	}
+	return creds, err
 }

--- a/wincred/wincred_windows.go
+++ b/wincred/wincred_windows.go
@@ -41,8 +41,6 @@ func (h Wincred) Get(serverURL string) (string, string, error) {
 // List returns the stored URLs and corresponding usernames.
 func (h Wincred) List() (map[string]string, error) {
 	creds, err := winc.List()
-	paths := make([]string, len(creds))
-	accts := make([]string, len(creds))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR updates the vendor pkg `wincred`:
- Removed need for `C` package (danieljoos/wincred@8d753fac3f8cec5374df7f303ba40237de62333e)
- Added some null-checks (addresses #21 - danieljoos/wincred@1c80202994708d42f05003601a4914ead119bf42)
- `List` returns an empty list instead of an error if no credentials are installed on the system (danieljoos/wincred@fd3b27f99d1b6b46c9a70e41d376bfff63af235f)

Other than that, it fixes the Windows build (`make wincred`) by removing two lines in `wincred_windows.go` that seem to be a leftover of the last merge #25 .
