### PR TITLE
C.free(unsafe.Pointer(err)) -> C.g_error_free(err)

### DIFF
--- a/secretservice/secretservice_linux.go
+++ b/secretservice/secretservice_linux.go
@@ -88,7 +88,7 @@ func (h Secretservice) List() (map[string]string, error) {
 	var listLenC C.uint
 	err := C.list(&pathsC, &acctsC, &listLenC)
 	if err != nil {
-		defer C.free(unsafe.Pointer(err))
+		defer C.g_error_free(err)
 		return nil, errors.New("Error from list function in secretservice_linux.c likely due to error in secretservice library")
 	}
 	defer C.freeListData(&pathsC, listLenC)


### PR DESCRIPTION
Fixes #23, #103, #104 
Signed-off-by: Jake Sanders jsand@google.com
