### PR TITLE
Add cgo flags to support older version of OSX (10.10, 10.11)

### DIFF
--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -1,8 +1,8 @@
 package osxkeychain
 
 /*
-#cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Security -framework Foundation
+#cgo CFLAGS: -x objective-c -mmacosx-version-min=10.10
+#cgo LDFLAGS: -framework Security -framework Foundation -mmacosx-version-min=10.10
 
 #include "osxkeychain_darwin.h"
 #include <stdlib.h>


### PR DESCRIPTION
Signed-off-by: Emmanuel Briney <emmanuel.briney@docker.com>