### PR TITLE
Add a makefile target to codesign output binary on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ deps:
 
 osxkeychain:
 	mkdir -p bin
-	go build -o bin/docker-credential-osxkeychain osxkeychain/cmd/main_darwin.go
+	go build -ldflags -s -o bin/docker-credential-osxkeychain osxkeychain/cmd/main_darwin.go
+
+codesign: osxkeychain
+	$(eval SIGNINGHASH = $(shell security find-identity -v -p codesigning | grep "Developer ID Application: Docker Inc" | cut -d ' ' -f 4))
+	xcrun -log codesign -s $(SIGNINGHASH) --force --verbose bin/docker-credential-osxkeychain
+	xcrun codesign --verify --deep --strict --verbose=2 --display bin/docker-credential-osxkeychain
 
 secretservice:
 	mkdir -p bin


### PR DESCRIPTION
- This allow the binary to be codesigned
- This is a specific target, if you build locally you can still use `osxkeychain` as usual.
- You need to have the cert installed on your building machine for the codesign to work