### PR TITLE
Fix secretservice tests and expected behaviors

### DIFF
--- a/secretservice/secretservice_linux_test.go
+++ b/secretservice/secretservice_linux_test.go
@@ -26,16 +26,13 @@ func TestSecretServiceHelper(t *testing.T) {
 
 	// If any docker credentials with the tests values we are providing, we
 	// remove them as they probably come from a previous failed test
-	if len(old_auths) >= 1 {
-		for k, v := range old_auths {
-			if strings.Compare(k, creds.ServerURL) == 0 && strings.Compare(v, creds.Username) == 0 {
+	for k, v := range old_auths {
+		if strings.Compare(k, creds.ServerURL) == 0 && strings.Compare(v, creds.Username) == 0 {
 
-				if err := helper.Delete(creds.ServerURL); err != nil {
-					t.Fatal(err)
-				}
+			if err := helper.Delete(creds.ServerURL); err != nil {
+				t.Fatal(err)
 			}
 		}
-
 	}
 
 	// Check again how many docker credentials we have when starting the test

--- a/secretservice/secretservice_linux_test.go
+++ b/secretservice/secretservice_linux_test.go
@@ -1,6 +1,7 @@
 package secretservice
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-credential-helpers/credentials"
@@ -16,10 +17,39 @@ func TestSecretServiceHelper(t *testing.T) {
 	}
 
 	helper := Secretservice{}
+
+	// Check how many docker credentials we have when starting the test
+	old_auths, err := helper.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// If any docker credentials with the tests values we are providing, we
+	// remove them as they probably come from a previous failed test
+	if len(old_auths) >= 1 {
+		for k, v := range old_auths {
+			if strings.Compare(k, creds.ServerURL) == 0 && strings.Compare(v, creds.Username) == 0 {
+
+				if err := helper.Delete(creds.ServerURL); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+	}
+
+	// Check again how many docker credentials we have when starting the test
+	old_auths, err = helper.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add new credentials
 	if err := helper.Add(creds); err != nil {
 		t.Fatal(err)
 	}
 
+	// Verify that it is inside the secret service store
 	username, secret, err := helper.Get(creds.ServerURL)
 	if err != nil {
 		t.Fatal(err)
@@ -33,15 +63,21 @@ func TestSecretServiceHelper(t *testing.T) {
 		t.Fatalf("expected %s, got %s\n", "foobarbaz", secret)
 	}
 
+	// We should have one more credential than before adding
+	new_auths, err := helper.List()
+	if err != nil || (len(new_auths)-len(old_auths) != 1) {
+		t.Fatal(err)
+	}
+	old_auths = new_auths
+
+	// Deleting the credentials associated to current server url should succeed
 	if err := helper.Delete(creds.ServerURL); err != nil {
 		t.Fatal(err)
 	}
-	auths, err := helper.List()
-	if err != nil || len(auths) == 0 {
-		t.Fatal(err)
-	}
-	helper.Add(creds)
-	if newauths, err := helper.List(); (len(newauths) - len(auths)) != 1 {
+
+	// We should have one less credential than before deleting
+	new_auths, err = helper.List()
+	if err != nil || (len(old_auths)-len(new_auths) != 1) {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The logic behind this PR's purpose and implementation can be found here: https://github.com/docker/docker-credential-helpers/issues/48

This PR needs the following PR to work properly: https://github.com/docker/docker-credential-helpers/pull/49 which fixes the broken `secureservice` implementation.

