### PR TITLE
Fix syntax typos and tests implementation for Windows

### DIFF
--- a/wincred/wincred_windows.go
+++ b/wincred/wincred_windows.go
@@ -51,10 +51,10 @@ func (h Wincred) List() (map[string]string, error) {
 
 	resp := make(map[string]string)
 	for i := range creds {
-		attrs = creds[i].Attributes
+		attrs := creds[i].Attributes
 		for _, attr := range attrs {
-			if !strings.Compare(attr.Keyword, "label") &&
-				!bytes.Compare(attr.Value, []byte(credentials.CredsLabel)) {
+			if strings.Compare(attr.Keyword, "label") == 0 &&
+				bytes.Compare(attr.Value, []byte(credentials.CredsLabel)) == 0 {
 
 				resp[creds[i].TargetName] = creds[i].UserName
 			}

--- a/wincred/wincred_windows_test.go
+++ b/wincred/wincred_windows_test.go
@@ -2,6 +2,7 @@ package wincred
 
 import (
 	"testing"
+	"strings"
 
 	"github.com/docker/docker-credential-helpers/credentials"
 )
@@ -19,6 +20,31 @@ func TestWinCredHelper(t *testing.T) {
 	}
 
 	helper := Wincred{}
+
+	// check for and remove remaining credentials from previous fail tests
+	oldauths, err := helper.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k, v := range oldauths {
+		if strings.Compare(k, creds.ServerURL) == 0 && strings.Compare(v, creds.Username) == 0 {
+			if err := helper.Delete(creds.ServerURL); err != nil {
+				t.Fatal(err)
+			}
+		} else if strings.Compare(k, creds1.ServerURL) == 0 && strings.Compare(v, creds1.Username) == 0 {
+			if err := helper.Delete(creds1.ServerURL); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// recount for credentials
+	oldauths, err = helper.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := helper.Add(creds); err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +63,7 @@ func TestWinCredHelper(t *testing.T) {
 	}
 
 	auths, err := helper.List()
-	if err != nil || len(auths) == 0 {
+	if err != nil || len(auths) - len(oldauths) != 1 {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
I'm sorry, I failed to commit all my changes it seems in the following PR: https://github.com/docker/docker-credential-helpers/pull/49

Main issue to be solved is still: https://github.com/docker/docker/issues/31517 . Now all platforms seem to be working well.

This commit fixes the Windows build as well as the tests for this platform.

Signed-off-by: Nassim 'Nass' Eddequiouaq <eddequiouaq.nassim@gmail.com>