### PR TITLE
Force serverURL to have https protocol

### DIFF
--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -11,6 +11,7 @@ import "C"
 import (
 	"errors"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -134,8 +135,17 @@ func (h Osxkeychain) List() (map[string]string, error) {
 	return resp, nil
 }
 
+// alwaysHTTPS takes a url and makes sure it always has the https protocol
+func alwaysHTTPS(url string) string {
+	re := regexp.MustCompile(`^\w+://`)
+	stripped := re.ReplaceAllLiteralString(url, "")
+	return ("https://" + stripped)
+}
+
 func splitServer(serverURL string) (*C.struct_Server, error) {
-	u, err := url.Parse(serverURL)
+	httpsServerURL := alwaysHTTPS(serverURL)
+
+	u, err := url.Parse(httpsServerURL)
 	if err != nil {
 		return nil, err
 	}

--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 	"unsafe"
 
 	"github.com/docker/docker-credential-helpers/credentials"
@@ -135,40 +134,47 @@ func (h Osxkeychain) List() (map[string]string, error) {
 	return resp, nil
 }
 
-// alwaysHTTPS takes a url and makes sure it always has the https protocol
-func alwaysHTTPS(url string) string {
-	re := regexp.MustCompile(`^\w+://`)
-	stripped := re.ReplaceAllLiteralString(url, "")
-	return ("https://" + stripped)
-}
-
+// splitServer() creates a proper server structure for OSX Keychain API
+// It normalizes if needed the format of the URL. Of no protocol is
+// provided, HTTPS will be used by default.
 func splitServer(serverURL string) (*C.struct_Server, error) {
-	httpsServerURL := alwaysHTTPS(serverURL)
+	// Check if we have a scheme in the URL as of RFC 3986, section 3.1
+	// and prepend '//' to normalize to a valid URL format
+	if !regexp.MustCompile(`^([a-zA-Z][-+.a-zA-Z0-9]+:)?//`).MatchString(serverURL) {
+		serverURL = "//" + serverURL
+	}
 
-	u, err := url.Parse(httpsServerURL)
+	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, err
 	}
 
-	hostAndPort := strings.Split(u.Host, ":")
-	host := hostAndPort[0]
+	// We only support HTTPS and HTTP for registries
+	if u.Scheme != "" && u.Scheme != "https" && u.Scheme != "http" {
+		return nil, errors.New("unsupported scheme: " + u.Scheme)
+	}
+
+	if u.Hostname() == "" {
+		return nil, errors.New("no hostname in URL")
+	}
+
+	// If no protocol is specified, we use HTTPS
+	proto := C.kSecProtocolTypeHTTPS
+	if u.Scheme == "http" {
+		proto = C.kSecProtocolTypeHTTP
+	}
+
 	var port int
-	if len(hostAndPort) == 2 {
-		p, err := strconv.Atoi(hostAndPort[1])
+	if u.Port() != "" {
+		port, err = strconv.Atoi(u.Port())
 		if err != nil {
 			return nil, err
 		}
-		port = p
-	}
-
-	proto := C.kSecProtocolTypeHTTPS
-	if u.Scheme != "https" {
-		proto = C.kSecProtocolTypeHTTP
 	}
 
 	return &C.struct_Server{
 		proto: C.SecProtocolType(proto),
-		host:  C.CString(host),
+		host:  C.CString(u.Host),
 		port:  C.uint(port),
 		path:  C.CString(u.Path),
 	}, nil

--- a/osxkeychain/osxkeychain_darwin_test.go
+++ b/osxkeychain/osxkeychain_darwin_test.go
@@ -54,6 +54,68 @@ func TestOSXKeychainHelper(t *testing.T) {
 	}
 }
 
+func TestOSXKeychainHelperIgnoresProtocol(t *testing.T) {
+	loginServerURL := "foobar.docker.io:2376"
+	pullServerURL1 := "http://foobar.docker.io:2376"
+	pullServerURL2 := "https://foobar.docker.io:2376"
+	pullServerURL3 := "ftp://foobar.docker.io:2376"
+
+	creds := &credentials.Credentials{
+		ServerURL: loginServerURL,
+		Username:  "foobar",
+		Secret:    "foobarbaz",
+	}
+	helper := Osxkeychain{}
+	defer helper.Delete(creds.ServerURL)
+	if err := helper.Add(creds); err != nil {
+		t.Fatal(err)
+	}
+
+	username1, secret1, err := helper.Get(pullServerURL1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username1 != "foobar" {
+		t.Fatalf("Error: expected username %s, got username %s", creds.Username, username1)
+	}
+	if secret1 != "foobarbaz" {
+		t.Fatalf("Error: expected secret %s, got secret %s", creds.Secret, secret1)
+	}
+
+	username2, secret2, err := helper.Get(pullServerURL2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username2 != "foobar" {
+		t.Fatalf("Error: expected username %s, got username %s", creds.Username, username2)
+	}
+	if secret2 != "foobarbaz" {
+		t.Fatalf("Error: expected secret %s, got secret %s", creds.Secret, secret2)
+	}
+
+	username3, secret3, err := helper.Get(pullServerURL3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username3 != "foobar" {
+		t.Fatalf("Error: expected username %s, got username %s", creds.Username, username3)
+	}
+	if secret3 != "foobarbaz" {
+		t.Fatalf("Error: expected secret %s, got secret %s", creds.Secret, secret3)
+	}
+
+	username, secret, err := helper.Get(loginServerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username != "foobar" {
+		t.Fatalf("Error: expected username %s, got username %s", creds.Username, username)
+	}
+	if secret != "foobarbaz" {
+		t.Fatalf("Error: expected secret %s, got secret %s", creds.Secret, secret)
+	}
+}
+
 func TestMissingCredentials(t *testing.T) {
 	helper := Osxkeychain{}
 	_, _, err := helper.Get("https://adsfasdf.wrewerwer.com/asdfsdddd")


### PR DESCRIPTION
See https://github.com/docker/docker-credential-helpers/issues/14#issuecomment-286532314

Docker login strips the protocol from serverURL, and docker pull prepends an `http` protocol to serverURL, resulting in:

1. creds from docker login not being stored correctly due to `net/url.Parse` not parsing protocol-less URLs correctly
2. Creds stored with a protocol-less URL not being able to be retrieved with a URL that has a protocol

I'm not sure the correct thing to do here, but since this url parsing is just done to store and retrieve credentials from the OSX keychain, it seems like it's OK to just normalize all `serverURL`s to have the `https` protocol.  This way, `net/url.Parse` will always parse them as expected, and they'll match among any different way that the docker command could pass them.