### PR TITLE
Workaround for Linux 32-bit build

### DIFF
--- a/secretservice/secretservice_linux.go
+++ b/secretservice/secretservice_linux.go
@@ -105,8 +105,11 @@ func (h Secretservice) List() (map[string]string, error) {
 	if listLen == 0 {
 		return resp, nil
 	}
-	pathTmp := (*[1 << 30]*C.char)(unsafe.Pointer(pathsC))[:listLen:listLen]
-	acctTmp := (*[1 << 30]*C.char)(unsafe.Pointer(acctsC))[:listLen:listLen]
+	// The maximum capacity of the following two slices is limited to (2^29)-1 to remain compatible
+	// with 32-bit platforms. The size of a `*C.char` (a pointer) is 4 Byte on a 32-bit system
+	// and (2^29)*4 == math.MaxInt32 + 1. -- See issue golang/go#13656
+	pathTmp := (*[(1 << 29) - 1]*C.char)(unsafe.Pointer(pathsC))[:listLen:listLen]
+	acctTmp := (*[(1 << 29) - 1]*C.char)(unsafe.Pointer(acctsC))[:listLen:listLen]
 	for i := 0; i < listLen; i++ {
 		resp[C.GoString(pathTmp[i])] = C.GoString(acctTmp[i])
 	}


### PR DESCRIPTION
This adds a workaround for the `secretservice` sub-package to build under 32bit Linux.
It limits the total number of list entries to 2^28!

Tested it to compile successfully under Debian jessie 32bit with golang 1.6.2.

Fixes #57