### PR TITLE
Update TravisCI to use Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@
   notifications:
     email: false
   go:
-    - 1.7
+    - 1.8
   install: make deps
   addons:
     apt:


### PR DESCRIPTION
To match the version used in docker

ping @n4ss @vdemeester PTAL