### PR TITLE
return "" instead of an error when pass isn't present

### DIFF
--- a/pass/pass_linux_test.go
+++ b/pass/pass_linux_test.go
@@ -54,9 +54,13 @@ func TestPassHelper(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, _, err = helper.Get(server)
-		if err == nil {
-			t.Fatalf("%s shuldn't exist any more", server)
+		username, _, err = helper.Get(server)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if username != "" {
+			t.Fatalf("%s shouldn't exist any more", username)
 		}
 	}
 


### PR DESCRIPTION
It turns out the cred helpers protocol is to return "" and not an error
when a credential isn't present, so let's do that.

Signed-off-by: Tycho Andersen <tycho@docker.com>