### PR TITLE
Fix typo and spelling error

### DIFF
--- a/pass/pass_linux.go
+++ b/pass/pass_linux.go
@@ -49,7 +49,7 @@ func (p Pass) checkInitialized() error {
 	// In principle, we could just run `pass init`. However, pass has a bug
 	// where if gpg fails, it doesn't always exit 1. Additionally, pass
 	// uses gpg2, but gpg is the default, which may be confusing. So let's
-	// just explictily check that pass actually can store and retreive a
+	// just explicitly check that pass actually can store and retrieve a
 	// password.
 	password := "pass is initialized"
 	name := path.Join(getPassDir(), "docker-pass-initialized-check")


### PR DESCRIPTION
This just fixes a typo and a spelling error in the comments.