### PR TITLE
pass: changed the way for checking if password-store is initalized

### DIFF
--- a/pass/pass_linux.go
+++ b/pass/pass_linux.go
@@ -46,25 +46,10 @@ func (p Pass) checkInitialized() error {
 	if passInitialized {
 		return nil
 	}
-	// In principle, we could just run `pass init`. However, pass has a bug
-	// where if gpg fails, it doesn't always exit 1. Additionally, pass
-	// uses gpg2, but gpg is the default, which may be confusing. So let's
-	// just explictily check that pass actually can store and retreive a
-	// password.
-	password := "pass is initialized"
-	name := path.Join(getPassDir(), "docker-pass-initialized-check")
-
-	_, err := p.runPassHelper(password, "insert", "-f", "-m", name)
+	// We just run a `pass ls`, if it fails then pass is not initialized.
+	_, err := p.runPassHelper("", "ls")
 	if err != nil {
 		return fmt.Errorf("error initializing pass: %v", err)
-	}
-
-	stored, err := p.runPassHelper("", "show", name)
-	if err != nil {
-		return fmt.Errorf("error fetching password during initialization: %v", err)
-	}
-	if stored != password {
-		return fmt.Errorf("error round-tripping password during initialization: %q != %q", password, stored)
 	}
 	passInitialized = true
 	return nil

--- a/pass/pass_linux.go
+++ b/pass/pass_linux.go
@@ -49,7 +49,7 @@ func (p Pass) checkInitialized() error {
 	// We just run a `pass ls`, if it fails then pass is not initialized.
 	_, err := p.runPassHelper("", "ls")
 	if err != nil {
-		return fmt.Errorf("error initializing pass: %v", err)
+		return fmt.Errorf("pass not initialized: %v", err)
 	}
 	passInitialized = true
 	return nil


### PR DESCRIPTION
Changed the way that `docker-credential-helpers` check if `password-store` is initialized.
The current way inserts and removes a password, each time it is called, to make sure that pass is initialized.

This creates a lot of commits if the password-store is made as a git repository (which is quite awful).
The following is how many commits has been made, over a span of ~2 months...

```
$ git log | grep 'docker-pass-initialized-check' | wc -l
1430
```

I have changed the way to just do a `pass ls`, as it will fail if pass is not initialized.
If it should fail, it will fail at a read of pass or insert of pass anyways, and therefore this solution is much more elegant.