### PR TITLE
Fix Travis configuration, update XCode version, Golang version and set to minimum macOS version to 10.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,14 @@
   sudo: required
   language: go
   dist: trusty
-  osx_image: xcode9
+  osx_image: xcode10.1
   os:
     - linux
     - osx
   notifications:
     email: false
   go:
-    - 1.8.1
-  before_install:
-    # work-around for issue https://github.com/travis-ci/travis-ci/issues/6307
-    # might not be necessary in the future
-    - command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-    - rvm get stable
+    - 1.12.x
   addons:
     apt:
       packages:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION := $(shell grep 'const Version' credentials/version.go | awk -F'"' '{ pr
 all: test
 
 deps:
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 
 clean:
 	rm -rf bin

--- a/credentials/version.go
+++ b/credentials/version.go
@@ -1,4 +1,4 @@
 package credentials
 
 // Version holds a string describing the current version
-const Version = "0.6.0"
+const Version = "0.6.1"

--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -1,8 +1,8 @@
 package osxkeychain
 
 /*
-#cgo CFLAGS: -x objective-c -mmacosx-version-min=10.10
-#cgo LDFLAGS: -framework Security -framework Foundation -mmacosx-version-min=10.10
+#cgo CFLAGS: -x objective-c -mmacosx-version-min=10.11
+#cgo LDFLAGS: -framework Security -framework Foundation -mmacosx-version-min=10.11
 
 #include "osxkeychain_darwin.h"
 #include <stdlib.h>


### PR DESCRIPTION
Using the new public key for RVM, update to golang 1.9.1 version…

Signed-off-by: Ulrich VACHON <ulrich.vachon@docker.com>