### PR TITLE
Fix docker-credential-osxkeychain list behaviour in case of missing entry in keychain

### DIFF
--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -113,6 +113,10 @@ func (h Osxkeychain) List() (map[string]string, error) {
 	if errMsg != nil {
 		defer C.free(unsafe.Pointer(errMsg))
 		goMsg := C.GoString(errMsg)
+		if goMsg == errCredentialsNotFound {
+			return make(map[string]string), nil
+		}
+
 		return nil, errors.New(goMsg)
 	}
 


### PR DESCRIPTION
Currently, `docker-credential-osxkeychain list` returns an error if the keychain entry is missing.

However, `docker logout` actually clears the `Docker Credentials` keychain entry. Meaning that after performing the logout, the calls to `docker-credential-osxkeychain list` returns an error.

When building images (at least with `docker-compose build`, did not try directly with `docker build`) calls to `docker-credential-osxkeychain list` are performed, resulting in build failure as the credential helpers returns a non-0 return code.

This is probably not the expected behaviour. Also, this is not the case on windows, as the used implementation from `danieljoos/wincred` correctly handles the case:

``` go
func List() ([]*Credential, error) {
	creds, err := nativeCredEnumerate("", true)
	if err != nil && err.Error() == naERROR_NOT_FOUND {
		// Ignore ERROR_NOT_FOUND and return an empty list instead
		creds = []*Credential{}
		err = nil
	}
	return creds, err
}
```

This PR changes the `docker-credential-osxkeychain list` behaviour to return an empty map if the keychain entry is missing.