### PR TITLE
Attempt to build this package on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@
   os:
     - linux
     - osx
+    - linux-ppc64le
   notifications:
     email: false
   go:
@@ -19,7 +20,7 @@
   before_script:
     - make deps
     - "export DISPLAY=:99.0"
-    - if [[ "$TRAVIS_OS_NAME" == "linux"  ]]; then sh ci/before_script_linux.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HOSTTYPE" != "powerpc64le" ]]; then sh ci/before_script_linux.sh; fi
     - make validate
   script: make test
 


### PR DESCRIPTION
 Adding power support in travis.yml
- Adding ppc64le build and running "before_script_linux.sh" on intel only via travis.yml

Signed-off-by: ghatwala <ghatwala@us.ibm.com>