### PR TITLE
[DESKTOP-1469] Update Windows Authenticode certificate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,8 @@ pipeline {
                     environment {
                         GOPATH      = pwd()
                         PATH        = "${pwd()}/bin;$PATH"
-                        PFX         = credentials('windows-build-pfx-sanitize')
-                        PFXPASSWORD = credentials('windows-build-pfx-password')
+                        PFX         = credentials('windows-build-2019-pfx')
+                        PFXPASSWORD = credentials('windows-build-2019-pfx-password')
                     }
                     steps {
                         dir('src/github.com/docker/docker-credential-helpers') {


### PR DESCRIPTION
Update the Windows Authenticode code signing certificate and password to the new one that is valid until 2021-10-01.

I've added it as new credential in Jenkins, so we can easily migrate (or rollback) per repo or release branch.
