### PR TITLE
Allow pass helper to be built for macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ RUN --mount=type=bind,target=. \
 EOT
 
 FROM base AS build-darwin
+ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 RUN --mount=type=bind,target=. \
@@ -121,6 +122,9 @@ RUN --mount=type=bind,target=. \
   xx-go install std
   xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-osxkeychain-${TARGETARCH}${TARGETVARIANT} ./osxkeychain/cmd/
   xx-verify /out/docker-credential-osxkeychain-${TARGETARCH}${TARGETVARIANT}
+
+  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-pass-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} ./pass/cmd/
+  xx-verify /out/docker-credential-pass-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}
 EOT
 
 FROM base AS build-windows

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ linuxrelease:
 osxrelease:
 	mkdir -p release
 	cd bin && tar cvfz ../release/docker-credential-osxkeychain-v$(VERSION)-amd64.tar.gz docker-credential-osxkeychain
+	cd bin && tar cvfz ../release/docker-credential-pass-v$(VERSION)-darwin-amd64.tar.gz docker-credential-pass
 
 winrelease:
 	mkdir -p release

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -22,7 +22,7 @@ import (
 // PASS_FOLDER contains the directory where credentials are stored
 const PASS_FOLDER = "docker-credential-helpers" //nolint:revive
 
-// Pass handles secrets using Linux secret-service as a store.
+// Pass handles secrets using pass as a store.
 type Pass struct{}
 
 // Ideally these would be stored as members of Pass, but since all of Pass's


### PR DESCRIPTION
Pass is described as "The Standard Unix Password Manager", and so it can
easily run on more than just Linux. Namely, it's supported on macOS. The
CLI is identical to the Linux build, which means the Linux helper code
for Pass is fully applicable toward the macOS build - a couple of
renames being the only needed thing, purely for semantic correctness.

Resolves https://github.com/docker/docker-credential-helpers/issues/146