### PR TITLE
Enabled ppc64le under "arch" instead of specifying under "os"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@
   os:
     - linux
     - osx
-    - linux-ppc64le
+  arch:
+    - ppc64le
   notifications:
     email: false
   go:


### PR DESCRIPTION
Enabled ppc64le under "arch" instead of specifying under "os"
arch:
    - ppc64le