### PR TITLE
Enabled ppc64le as an architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@
   os:
     - linux
     - osx
-    - linux-ppc64le
+  arch:
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ppc64le else amd64 fi
   notifications:
     email: false
   go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
     - linux
     - osx
   arch:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ppc64le else amd64 fi
+    - ppc64le
   notifications:
     email: false
   go:


### PR DESCRIPTION
Enabled ppc64le under "arch" instead of specifying under "os"
arch:
    - ppc64le