### PR TITLE
Add newline to stored secret

### DIFF
--- a/pass/pass_linux.go
+++ b/pass/pass_linux.go
@@ -86,7 +86,7 @@ func (h Pass) Add(creds *credentials.Credentials) error {
 
 	encoded := base64.URLEncoding.EncodeToString([]byte(creds.ServerURL))
 
-	_, err := h.runPass(creds.Secret, "insert", "-f", "-m", path.Join(PASS_FOLDER, encoded, creds.Username))
+	_, err := h.runPass(creds.Secret + "\n", "insert", "-f", "-m", path.Join(PASS_FOLDER, encoded, creds.Username))
 	return err
 }
 


### PR DESCRIPTION
The information stored in password-store should have a newline.

This makes printing not broken (i.e. prompt appears on next line)

unix files should end with a newline