### PR TITLE
travis: update to Ubuntu "focal", bump Go to 1.15.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
   # See appveyor.yml for windows build.
   sudo: required
   language: go
-  dist: trusty
+  dist: focal
   osx_image: xcode10.1
   os:
     - linux
@@ -11,10 +11,11 @@
   notifications:
     email: false
   go:
-    - 1.12.x
+    - 1.15.x
   addons:
     apt:
       packages:
+        - libsecret-1
         - libsecret-1-dev
         - pass
   before_script:

--- a/ci/before_script_linux.sh
+++ b/ci/before_script_linux.sh
@@ -1,6 +1,6 @@
 set -ex
 
-sh -e /etc/init.d/xvfb start
+sh -e systemctl start xvfb
 sleep 3 # give xvfb some time to start
 
 # init key for pass


### PR DESCRIPTION
See if this fixes the issue seen in https://github.com/docker/docker-credential-helpers/pull/193#issuecomment-758552058