### PR TITLE
Set a better displaylabel for secretservice

### DIFF
--- a/secretservice/secretservice_linux.c
+++ b/secretservice/secretservice_linux.c
@@ -17,11 +17,11 @@ const SecretSchema *docker_get_schema(void)
 	return &docker_schema;
 }
 
-GError *add(char *label, char *server, char *username, char *secret) {
+GError *add(char *label, char *server, char *username, char *secret, char *displaylabel) {
 	GError *err = NULL;
 
 	secret_password_store_sync (DOCKER_SCHEMA, SECRET_COLLECTION_DEFAULT,
-			server, secret, NULL, &err,
+			displaylabel, secret, NULL, &err,
 			"label", label,
 			"server", server,
 			"username", username,

--- a/secretservice/secretservice_linux.go
+++ b/secretservice/secretservice_linux.go
@@ -30,8 +30,10 @@ func (h Secretservice) Add(creds *credentials.Credentials) error {
 	defer C.free(unsafe.Pointer(username))
 	secret := C.CString(creds.Secret)
 	defer C.free(unsafe.Pointer(secret))
+	displayLabel := C.CString("Docker credentials for " + creds.ServerURL)
+	defer C.free(unsafe.Pointer(displayLabel))
 
-	if err := C.add(credsLabel, server, username, secret); err != nil {
+	if err := C.add(credsLabel, server, username, secret, displayLabel); err != nil {
 		defer C.g_error_free(err)
 		errMsg := (*C.char)(unsafe.Pointer(err.message))
 		return errors.New(C.GoString(errMsg))

--- a/secretservice/secretservice_linux.h
+++ b/secretservice/secretservice_linux.h
@@ -6,7 +6,7 @@ const SecretSchema *docker_get_schema(void) G_GNUC_CONST;
 
 #define DOCKER_SCHEMA docker_get_schema()
 
-GError *add(char *label, char *server, char *username, char *secret);
+GError *add(char *label, char *server, char *username, char *secret, char *displaylabel);
 GError *delete(char *server);
 GError *get(char *server, char **username, char **secret);
 GError *list(char *label, char *** paths, char *** accts, unsigned int *list_l);


### PR DESCRIPTION
Secretservice entries have a "label". This is intended to be a
human-readable description. It's actually called "Description" in UIs
like seahorse, and the listing of existing secrets shows this as a name
for each one.

The entries stored by the credential helper set this to simply the
repository URL. This is rather unfriendly, since entries like
"gitlab.com" and "index.docker.io/v1" show up. Mixed in with
entries from all other applications, it's hard to figure out what
application owns each entry.

This commit changes the label used when saving entries to be something
human-readable (this is the intent of the "label" field, btw). Because
of the naming scheme, this also results in all entries being shown
together by default (since UIs tend to sort lexicographically).

New entries will now be stores as:

    Docker credentials for $REGISTRY_URL

Note that items stored by the secret service have multiple fields inside
of them. One of those fields is called "label", and is used by the
helper to filter items from the secret service. This "label" field is
entirely unrelated to the items' label. The naming is most unfortunate.