### PR TITLE
Test stage and ci jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,71 @@ on:
 
 env:
   DESTDIR: ./bin
+  GO_VERSION: 1.16.7
 
 jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macOS-11
+          - windows-2022
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      -
+        name: Install deps
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dbus-x11 gnome-keyring libsecret-1-dev pass
+      -
+        name: Test
+        run: |
+          go test -short -v -coverprofile=./coverage.txt -covermode=atomic ./...
+          go tool cover -func=./coverage.txt
+        shell: bash
+      -
+        name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.txt
+
+  test-sandboxed:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Test
+        uses: docker/bake-action@v2
+        with:
+          targets: test
+          set: |
+            *.cache-from=type=gha,scope=test
+            *.cache-to=type=gha,scope=test,mode=max
+      -
+        name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: ${{ env.DESTDIR }}//coverage.txt
+
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout
@@ -30,6 +91,9 @@ jobs:
         uses: docker/bake-action@v2
         with:
           targets: binaries
+          set: |
+            *.cache-from=type=gha,scope=build
+            *.cache-to=type=gha,scope=build,mode=max
       -
         name: Move artifacts
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,18 @@ FROM gobase AS base
 ARG TARGETPLATFORM
 RUN xx-apk add musl-dev gcc libsecret-dev pass
 
+FROM base AS test
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg/mod <<EOT
+  set -e
+  xx-go test -short -v -coverprofile=/tmp/coverage.txt -covermode=atomic ./...
+  xx-go tool cover -func=/tmp/coverage.txt
+EOT
+
+FROM scratch AS test-coverage
+COPY --from=test /tmp/coverage.txt /coverage.txt
+
 FROM base AS build-linux
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![GitHub release](https://img.shields.io/github/release/docker/docker-credential-helpers.svg?style=flat-square)](https://github.com/docker/docker-credential-helpers/releases/latest)
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?style=flat-square&logo=go&logoColor=white)](https://pkg.go.dev/github.com/docker/docker-credential-helpers)
+[![Build Status](https://img.shields.io/github/workflow/status/docker/docker-credential-helpers/build?label=build&logo=github&style=flat-square)](https://github.com/docker/docker-credential-helpers/actions?query=workflow%3Abuild)
+[![Codecov](https://img.shields.io/codecov/c/github/docker/docker-credential-helpers?logo=codecov&style=flat-square)](https://codecov.io/gh/docker/docker-credential-helpers)
+[![Go Report Card](https://goreportcard.com/badge/github.com/docker/docker-credential-helpers?style=flat-square)](https://goreportcard.com/report/github.com/docker/docker-credential-helpers)
+
 ## Introduction
 
 docker-credential-helpers is a suite of programs to use native stores to keep Docker credentials safe.
@@ -6,9 +12,21 @@ docker-credential-helpers is a suite of programs to use native stores to keep Do
 
 Go to the [Releases](https://github.com/docker/docker-credential-helpers/releases) page and download the binary that works better for you. Put that binary in your `$PATH`, so Docker can find it.
 
-### Building from scratch
+## Building
 
-The programs in this repository are written with the Go programming language. These instructions assume that you have previous knowledge about the language and you have it installed in your machine.
+You can build the credential helpers using Docker:
+
+```shell
+# create builder
+$ docker buildx create --use
+# build credential helpers from remote repository and output to ./bin/build
+$ docker buildx bake "https://github.com/docker/docker-credential-helpers.git"
+# or from local source
+$ git clone https://github.com/docker/docker-credential-helpers.git
+$ docker buildx bake
+```
+
+Or if the toolchain is already installed on your machine:
 
 1 - Download the source and put it in your `$GOPATH` with `go get`.
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,8 +1,14 @@
 variable "GO_VERSION" {
   default = "1.16.7"
 }
+
+# Defines the output folder
 variable "DESTDIR" {
-  default = "./bin"
+  default = ""
+}
+function "bindir" {
+  params = [defaultdir]
+  result = DESTDIR != "" ? DESTDIR : "./bin/${defaultdir}"
 }
 
 target "_common" {
@@ -15,10 +21,16 @@ group "default" {
   targets = ["binaries"]
 }
 
+target "test" {
+  inherits = ["_common"]
+  target = "test-coverage"
+  output = [bindir("coverage")]
+}
+
 target "binaries" {
   inherits = ["_common"]
   target = "binaries"
-  output = [DESTDIR]
+  output = [bindir("build")]
   platforms = [
     "darwin/amd64",
     "darwin/arm64",


### PR DESCRIPTION
follow-up https://github.com/docker/docker-credential-helpers/pull/209

Tests run on specific runners with respect to the target OS and the results are merged and sent to Codecov. Containerized tests are only available for host platform atm (that's why a specific job has been added in the build workflow).

cc @thaJeztah 