### PR TITLE
secretservice: allow building on openbsd

### DIFF
--- a/secretservice/secretservice.go
+++ b/secretservice/secretservice.go
@@ -1,4 +1,4 @@
-//go:build linux && cgo
+//go:build (linux || openbsd) && cgo
 
 package secretservice
 

--- a/secretservice/secretservice_test.go
+++ b/secretservice/secretservice_test.go
@@ -1,4 +1,4 @@
-//go:build linux && cgo
+//go:build (linux || openbsd) && cgo
 
 package secretservice
 


### PR DESCRIPTION
- rebase of https://github.com/docker/docker-credential-helpers/pull/188 (repository for that PR was deleted)
- closes https://github.com/docker/docker-credential-helpers/pull/188

There is nothing linux specific about secretservice. I was able to
build it on openbsd with this change.
