### PR TITLE
Dockerfile: de-duplicate args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN --mount=target=. \
 
 FROM gobase AS base
 ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 RUN xx-apk add musl-dev gcc libsecret-dev pass
 
 FROM base AS test
@@ -43,9 +46,6 @@ FROM scratch AS test-coverage
 COPY --from=test /tmp/coverage.txt /coverage.txt
 
 FROM base AS build-linux
-ARG TARGETOS
-ARG TARGETARCH
-ARG TARGETVARIANT
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \
@@ -59,8 +59,6 @@ RUN --mount=type=bind,target=. \
 EOT
 
 FROM base AS build-darwin
-ARG TARGETARCH
-ARG TARGETVARIANT
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \
@@ -74,8 +72,6 @@ RUN --mount=type=bind,target=. \
 EOT
 
 FROM base AS build-windows
-ARG TARGETARCH
-ARG TARGETVARIANT
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \


### PR DESCRIPTION
When extending a stage, the new stage is considered a
breakpoint, so

    FROM foo AS one
    ARG something

    FROM one AS two
    # ARG is present here as well

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>