### PR TITLE
simplify "go build" commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,9 @@ RUN --mount=type=bind,target=. \
     --mount=type=bind,from=version,source=/tmp/.ldflags,target=/tmp/.ldflags <<EOT
   set -ex
   mkdir /out
-  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-pass-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} ./pass/cmd/main.go
+  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-pass-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} ./pass/cmd/
   xx-verify /out/docker-credential-pass-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}
-  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-secretservice-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} ./secretservice/cmd/main_linux.go
+  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-secretservice-${TARGETOS}-${TARGETARCH}${TARGETVARIANT} ./secretservice/cmd/
   xx-verify /out/docker-credential-secretservice-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}
 EOT
 
@@ -98,7 +98,7 @@ RUN --mount=type=bind,target=. \
   set -ex
   mkdir /out
   xx-go install std
-  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-osxkeychain-${TARGETARCH}${TARGETVARIANT} ./osxkeychain/cmd/main_darwin.go
+  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-osxkeychain-${TARGETARCH}${TARGETVARIANT} ./osxkeychain/cmd/
   xx-verify /out/docker-credential-osxkeychain-${TARGETARCH}${TARGETVARIANT}
 EOT
 
@@ -111,7 +111,7 @@ RUN --mount=type=bind,target=. \
     --mount=type=bind,from=version,source=/tmp/.ldflags,target=/tmp/.ldflags <<EOT
   set -ex
   mkdir /out
-  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-wincred-${TARGETARCH}${TARGETVARIANT}.exe ./wincred/cmd/main_windows.go
+  xx-go build -ldflags "$(cat /tmp/.ldflags)" -o /out/docker-credential-wincred-${TARGETARCH}${TARGETVARIANT}.exe ./wincred/cmd/
   xx-verify /out/docker-credential-wincred-${TARGETARCH}${TARGETVARIANT}.exe
 EOT
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 osxkeychain:
 	mkdir -p bin
-	go build -ldflags -s -o bin/docker-credential-osxkeychain osxkeychain/cmd/main_darwin.go
+	go build -ldflags -s -o bin/docker-credential-osxkeychain osxkeychain/cmd/
 
 osxcodesign: osxkeychain
 	$(eval SIGNINGHASH = $(shell security find-identity -v -p codesigning | grep "Developer ID Application: Docker Inc" | cut -d ' ' -f 4))
@@ -23,15 +23,15 @@ osxcodesign: osxkeychain
 
 secretservice:
 	mkdir -p bin
-	go build -o bin/docker-credential-secretservice secretservice/cmd/main_linux.go
+	go build -o bin/docker-credential-secretservice secretservice/cmd/
 
 pass:
 	mkdir -p bin
-	go build -o bin/docker-credential-pass pass/cmd/main.go
+	go build -o bin/docker-credential-pass pass/cmd/
 
 wincred:
 	mkdir -p bin
-	go build -o bin/docker-credential-wincred.exe wincred/cmd/main_windows.go
+	go build -o bin/docker-credential-wincred.exe wincred/cmd/
 
 linuxrelease:
 	mkdir -p release


### PR DESCRIPTION
There's no need to specify the file to build, as we're building the "main" packages as a whole.
