### PR TITLE
Use relative paths in Makefile for "go build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 
 osxkeychain:
 	mkdir -p bin
-	go build -ldflags -s -o bin/docker-credential-osxkeychain osxkeychain/cmd/
+	go build -ldflags -s -o bin/docker-credential-osxkeychain ./osxkeychain/cmd/
 
 osxcodesign: osxkeychain
 	$(eval SIGNINGHASH = $(shell security find-identity -v -p codesigning | grep "Developer ID Application: Docker Inc" | cut -d ' ' -f 4))
@@ -19,15 +19,15 @@ osxcodesign: osxkeychain
 
 secretservice:
 	mkdir -p bin
-	go build -o bin/docker-credential-secretservice secretservice/cmd/
+	go build -o bin/docker-credential-secretservice ./secretservice/cmd/
 
 pass:
 	mkdir -p bin
-	go build -o bin/docker-credential-pass pass/cmd/
+	go build -o bin/docker-credential-pass ./pass/cmd/
 
 wincred:
 	mkdir -p bin
-	go build -o bin/docker-credential-wincred.exe wincred/cmd/
+	go build -o bin/docker-credential-wincred.exe ./wincred/cmd/
 
 linuxrelease:
 	mkdir -p release


### PR DESCRIPTION
https://github.com/docker/docker-credential-helpers/pull/232#issuecomment-1226943341

Fixes #232
