### PR TITLE
Dockerfile: debian based build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
       -
         name: Check artifacts
         run: |
-          find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
+          find ${{ env.DESTDIR }} -type f -exec file -e ascii -e text -- {} +
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 
 ARG GO_VERSION=1.18.5
 ARG XX_VERSION=1.1.2
-ARG OSXCROSS_VERSION=11.3-r7-alpine
+ARG OSXCROSS_VERSION=11.3-r7-debian
 ARG GOLANGCI_LINT_VERSION=v1.47.3
+ARG DEBIAN_FRONTEND=noninteractive
 
 ARG PACKAGE=github.com/docker/docker-credential-helpers
 
@@ -13,9 +14,10 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 # osxcross contains the MacOSX cross toolchain for xx
 FROM crazymax/osxcross:${OSXCROSS_VERSION} AS osxcross
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS gobase
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bullseye AS gobase
 COPY --from=xx / /
-RUN apk add --no-cache clang file git lld llvm make pkgconf rsync
+ARG DEBIAN_FRONTEND
+RUN apt-get update && apt-get install -y --no-install-recommends clang dpkg-dev file git lld llvm make pkg-config rsync
 ENV GOFLAGS="-mod=vendor"
 ENV CGO_ENABLED="1"
 WORKDIR /src
@@ -49,9 +51,10 @@ RUN --mount=type=bind,target=.,rw <<EOT
   fi
 EOT
 
-FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
+FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION} AS golangci-lint
 FROM gobase AS lint
-RUN apk add musl-dev gcc libsecret-dev pass
+ARG DEBIAN_FRONTEND
+RUN apt-get install -y binutils gcc libc6-dev libgcc-10-dev libsecret-1-dev pkg-config
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=from=golangci-lint,source=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
@@ -59,10 +62,12 @@ RUN --mount=type=bind,target=. \
 
 FROM gobase AS base
 ARG TARGETPLATFORM
-RUN xx-apk add musl-dev gcc libsecret-dev pass
+ARG DEBIAN_FRONTEND
+RUN xx-apt-get install -y binutils gcc libc6-dev libgcc-10-dev libsecret-1-dev pkg-config
 
 FROM base AS test
-RUN xx-apk add gnome-keyring gpg-agent gnupg-gpgconf pass
+ARG DEBIAN_FRONTEND
+RUN xx-apt-get install -y dbus-x11 gnome-keyring gpg-agent gpgconf libsecret-1-dev pass
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod <<EOT
@@ -70,12 +75,14 @@ RUN --mount=type=bind,target=. \
   cp -r .github/workflows/fixtures /root/.gnupg
   gpg-connect-agent "RELOADAGENT" /bye
   gpg --import --batch --yes /root/.gnupg/7D851EB72D73BDA0.key
-  echo -e "trust\n5\ny" | gpg --batch --no-tty --command-fd 0 --edit-key 7D851EB72D73BDA0
+  gpg --update-trustdb
+  echo '5\ny\n' | gpg --command-fd 0 --no-tty --edit-key 7D851EB72D73BDA0 trust
   gpg-connect-agent "PRESET_PASSPHRASE 3E2D1142AA59E08E16B7E2C64BA6DDC773B1A627 -1 77697468207374757069642070617373706872617365" /bye
   gpg-connect-agent "KEYINFO 3E2D1142AA59E08E16B7E2C64BA6DDC773B1A627" /bye
   gpg-connect-agent "PRESET_PASSPHRASE BA83FC8947213477F28ADC019F6564A956456163 -1 77697468207374757069642070617373706872617365" /bye
   gpg-connect-agent "KEYINFO BA83FC8947213477F28ADC019F6564A956456163" /bye
   pass init 7D851EB72D73BDA0
+  gpg -k
 
   mkdir /out
   xx-go test -short -v -coverprofile=/out/coverage.txt -covermode=atomic ./...

--- a/pass/pass_test.go
+++ b/pass/pass_test.go
@@ -16,6 +16,8 @@ func TestPassHelper(t *testing.T) {
 		Secret:    "isthebestmeshuggahalbum",
 	}
 
+	_ = helper.CheckInitialized()
+
 	helper.Add(creds)
 
 	creds.ServerURL = "https://foobar.docker.io:9999/v2"


### PR DESCRIPTION
follow-up https://github.com/docker/docker-credential-helpers/pull/237#issuecomment-1230324172

using musl to build dynamically linked secretservice helper is not suitable so switch to debian based as it is for current released binaries.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>