### PR TITLE
format code with gofumpt

### DIFF
--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -37,7 +37,7 @@ func (m *memoryStore) Get(serverURL string) (string, string, error) {
 }
 
 func (m *memoryStore) List() (map[string]string, error) {
-	//Simply a placeholder to let memoryStore be a valid implementation of Helper interface
+	// Simply a placeholder to let memoryStore be a valid implementation of Helper interface
 	return nil, nil
 }
 
@@ -235,14 +235,14 @@ func TestEraseMissingServerURL(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	//This tests that there is proper input an output into the byte stream
-	//Individual stores are very OS specific and have been tested in osxkeychain and secretservice respectively
+	// This tests that there is proper input an output into the byte stream
+	// Individual stores are very OS specific and have been tested in osxkeychain and secretservice respectively
 	out := new(bytes.Buffer)
 	h := newMemoryStore()
 	if err := List(h, out); err != nil {
 		t.Fatal(err)
 	}
-	//testing that there is an output
+	// testing that there is an output
 	if out.Len() == 0 {
 		t.Fatalf("expected output in the writer, got %d", 0)
 	}

--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -8,6 +8,7 @@ package osxkeychain
 #include <stdlib.h>
 */
 import "C"
+
 import (
 	"errors"
 	"strconv"

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -28,11 +28,12 @@ type Pass struct{}
 // Ideally these would be stored as members of Pass, but since all of Pass's
 // methods have value receivers, not pointer receivers, and changing that is
 // backwards incompatible, we assume that all Pass instances share the same configuration
-
-// initializationMutex is held while initializing so that only one 'pass'
-// round-tripping is done to check pass is functioning.
-var initializationMutex sync.Mutex
-var passInitialized bool
+var (
+	// initializationMutex is held while initializing so that only one 'pass'
+	// round-tripping is done to check pass is functioning.
+	initializationMutex sync.Mutex
+	passInitialized     bool
+)
 
 // CheckInitialized checks whether the password helper can be used. It
 // internally caches and so may be safely called multiple times with no impact

--- a/secretservice/secretservice_linux.go
+++ b/secretservice/secretservice_linux.go
@@ -7,6 +7,7 @@ package secretservice
 #include <stdlib.h>
 */
 import "C"
+
 import (
 	"errors"
 	"unsafe"

--- a/secretservice/secretservice_linux_test.go
+++ b/secretservice/secretservice_linux_test.go
@@ -28,7 +28,6 @@ func TestSecretServiceHelper(t *testing.T) {
 	// remove them as they probably come from a previous failed test
 	for k, v := range oldAuths {
 		if strings.Compare(k, creds.ServerURL) == 0 && strings.Compare(v, creds.Username) == 0 {
-
 			if err := helper.Delete(creds.ServerURL); err != nil {
 				t.Fatal(err)
 			}

--- a/wincred/wincred_windows.go
+++ b/wincred/wincred_windows.go
@@ -111,15 +111,15 @@ func exactMatch(serverURL, target url.URL) bool {
 }
 
 func approximateMatch(serverURL, target url.URL) bool {
-	//if scheme is missing assume it is the same as target
+	// if scheme is missing assume it is the same as target
 	if serverURL.Scheme == "" {
 		serverURL.Scheme = target.Scheme
 	}
-	//if port is missing assume it is the same as target
+	// if port is missing assume it is the same as target
 	if serverURL.Port() == "" && target.Port() != "" {
 		serverURL.Host = serverURL.Host + ":" + target.Port()
 	}
-	//if path is missing assume it is the same as target
+	// if path is missing assume it is the same as target
 	if serverURL.Path == "" {
 		serverURL.Path = target.Path
 	}


### PR DESCRIPTION
Doing a one-pass of formatting the code with gofumpt, which provides a superset of gofmt.