### PR TITLE
rewrite tests to use sub-tests, improve error-handling in tests, and use t.Cleanup()

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -113,7 +113,7 @@ func TestStore(t *testing.T) {
 
 	for _, v := range valid {
 		if err := Store(mockProgramFn, &v); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}
 
@@ -123,7 +123,7 @@ func TestStore(t *testing.T) {
 
 	for _, v := range invalid {
 		if err := Store(mockProgramFn, &v); err == nil {
-			t.Fatalf("Expected error for server %s, got nil", v.ServerURL)
+			t.Errorf("Expected error for server %s, got nil", v.ServerURL)
 		}
 	}
 }
@@ -152,10 +152,10 @@ func TestGet(t *testing.T) {
 		}
 
 		if c.Username != v.Username {
-			t.Fatalf("expected username `%s`, got %s", v.Username, c.Username)
+			t.Errorf("expected username `%s`, got %s", v.Username, c.Username)
 		}
 		if c.Secret != v.Secret {
-			t.Fatalf("expected secret `%s`, got %s", v.Secret, c.Secret)
+			t.Errorf("expected secret `%s`, got %s", v.Secret, c.Secret)
 		}
 	}
 
@@ -165,10 +165,17 @@ func TestGet(t *testing.T) {
 		serverURL string
 		err       string
 	}{
-		{missingCredsAddress, credentials.NewErrCredentialsNotFound().Error()},
-		{invalidServerAddress, "error getting credentials - err: exited 1, out: `program failed`"},
-		{"", fmt.Sprintf("error getting credentials - err: %s, out: `%s`",
-			missingServerURLErr.Error(), missingServerURLErr.Error())},
+		{
+			serverURL: missingCredsAddress,
+			err:       credentials.NewErrCredentialsNotFound().Error(),
+		},
+		{
+			serverURL: invalidServerAddress,
+			err:       "error getting credentials - err: exited 1, out: `program failed`",
+		},
+		{
+			err: fmt.Sprintf("error getting credentials - err: %s, out: `%s`", missingServerURLErr.Error(), missingServerURLErr.Error()),
+		},
 	}
 
 	for _, v := range invalid {
@@ -177,7 +184,7 @@ func TestGet(t *testing.T) {
 			t.Fatalf("Expected error for server %s, got nil", v.serverURL)
 		}
 		if err.Error() != v.err {
-			t.Fatalf("Expected error `%s`, got `%v`", v.err, err)
+			t.Errorf("Expected error `%s`, got `%v`", v.err, err)
 		}
 	}
 }
@@ -192,11 +199,11 @@ func ExampleErase() {
 
 func TestErase(t *testing.T) {
 	if err := Erase(mockProgramFn, validServerAddress); err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	if err := Erase(mockProgramFn, invalidServerAddress); err == nil {
-		t.Fatalf("Expected error for server %s, got nil", invalidServerAddress)
+		t.Errorf("Expected error for server %s, got nil", invalidServerAddress)
 	}
 }
 
@@ -207,6 +214,6 @@ func TestList(t *testing.T) {
 	}
 
 	if username, exists := auths[validServerAddress]; !exists || username != validUsername {
-		t.Fatalf("auths[%s] returned %s, %t; expected %s, %t", validServerAddress, username, exists, validUsername, true)
+		t.Errorf("auths[%s] returned %s, %t; expected %s, %t", validServerAddress, username, exists, validUsername, true)
 	}
 }

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -42,7 +42,7 @@ func (m *memoryStore) List() (map[string]string, error) {
 }
 
 func TestStore(t *testing.T) {
-	serverURL := "https://index.docker.io/v1/"
+	const serverURL = "https://index.docker.io/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -65,11 +65,11 @@ func TestStore(t *testing.T) {
 	}
 
 	if c.Username != "foo" {
-		t.Fatalf("expected username foo, got %s\n", c.Username)
+		t.Errorf("expected username foo, got %s\n", c.Username)
 	}
 
 	if c.Secret != "bar" {
-		t.Fatalf("expected username bar, got %s\n", c.Secret)
+		t.Errorf("expected username bar, got %s\n", c.Secret)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestStoreMissingServerURL(t *testing.T) {
 	h := newMemoryStore()
 
 	if err := Store(h, in); IsCredentialsMissingServerURL(err) == false {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -109,12 +109,12 @@ func TestStoreMissingUsername(t *testing.T) {
 	h := newMemoryStore()
 
 	if err := Store(h, in); IsCredentialsMissingUsername(err) == false {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestGet(t *testing.T) {
-	serverURL := "https://index.docker.io/v1/"
+	const serverURL = "https://index.docker.io/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -147,16 +147,16 @@ func TestGet(t *testing.T) {
 	}
 
 	if c.Username != "foo" {
-		t.Fatalf("expected username foo, got %s\n", c.Username)
+		t.Errorf("expected username foo, got %s\n", c.Username)
 	}
 
 	if c.Secret != "bar" {
-		t.Fatalf("expected username bar, got %s\n", c.Secret)
+		t.Errorf("expected username bar, got %s\n", c.Secret)
 	}
 }
 
 func TestGetMissingServerURL(t *testing.T) {
-	serverURL := "https://index.docker.io/v1/"
+	const serverURL = "https://index.docker.io/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -177,12 +177,12 @@ func TestGetMissingServerURL(t *testing.T) {
 	w := new(bytes.Buffer)
 
 	if err := Get(h, buf, w); IsCredentialsMissingServerURL(err) == false {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
 func TestErase(t *testing.T) {
-	serverURL := "https://index.docker.io/v1/"
+	const serverURL = "https://index.docker.io/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -206,12 +206,12 @@ func TestErase(t *testing.T) {
 
 	w := new(bytes.Buffer)
 	if err := Get(h, buf, w); err == nil {
-		t.Fatal("expected error getting missing creds, got empty")
+		t.Error("expected error getting missing creds, got empty")
 	}
 }
 
 func TestEraseMissingServerURL(t *testing.T) {
-	serverURL := "https://index.docker.io/v1/"
+	const serverURL = "https://index.docker.io/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -244,6 +244,6 @@ func TestList(t *testing.T) {
 	}
 	// testing that there is an output
 	if out.Len() == 0 {
-		t.Fatalf("expected output in the writer, got %d", 0)
+		t.Error("expected output in the writer, got 0")
 	}
 }

--- a/osxkeychain/osxkeychain_darwin_test.go
+++ b/osxkeychain/osxkeychain_darwin_test.go
@@ -98,17 +98,19 @@ func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
-		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
-			continue
-		}
-		if _, _, err := helper.Get(tc.readURL); err != nil {
-			t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
-		}
-		if err := helper.Delete(tc.storeURL); err != nil {
-			t.Error(err)
-		}
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
+			if err := helper.Add(c); err != nil {
+				t.Fatalf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
+			}
+			if _, _, err := helper.Get(tc.readURL); err != nil {
+				t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
+			}
+			if err := helper.Delete(tc.storeURL); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 
@@ -171,17 +173,19 @@ func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
-		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
-			continue
-		}
-		if _, _, err := helper.Get(tc.readURL); err == nil {
-			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
-		}
-		if err := helper.Delete(tc.storeURL); err != nil {
-			t.Error(err)
-		}
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
+			if err := helper.Add(c); err != nil {
+				t.Fatalf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
+			}
+			if _, _, err := helper.Get(tc.readURL); err == nil {
+				t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
+			}
+			if err := helper.Delete(tc.storeURL); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 
@@ -220,27 +224,28 @@ func TestOSXKeychainHelperStoreRetrieve(t *testing.T) {
 	// Note that we don't delete between individual tests here, to verify that
 	// subsequent stores/overwrites don't affect storing / retrieving secrets.
 	for i, tc := range tests {
-		c := &credentials.Credentials{
-			ServerURL: tc.url,
-			Username:  fmt.Sprintf("user-%d", i),
-			Secret:    fmt.Sprintf("secret-%d", i),
-		}
+		tc := tc
+		t.Run(tc.url, func(t *testing.T) {
+			c := &credentials.Credentials{
+				ServerURL: tc.url,
+				Username:  fmt.Sprintf("user-%d", i),
+				Secret:    fmt.Sprintf("secret-%d", i),
+			}
 
-		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL: %s: %s", tc.url, err)
-			continue
-		}
-		user, secret, err := helper.Get(tc.url)
-		if err != nil {
-			t.Errorf("Error: failed to read secret for URL %q: %s", tc.url, err)
-			continue
-		}
-		if user != c.Username {
-			t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, tc.url)
-		}
-		if secret != c.Secret {
-			t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, tc.url)
-		}
+			if err := helper.Add(c); err != nil {
+				t.Fatalf("Error: failed to store secret for URL: %s: %s", tc.url, err)
+			}
+			user, secret, err := helper.Get(tc.url)
+			if err != nil {
+				t.Fatalf("Error: failed to read secret for URL %q: %s", tc.url, err)
+			}
+			if user != c.Username {
+				t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, tc.url)
+			}
+			if secret != c.Secret {
+				t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, tc.url)
+			}
+		})
 	}
 }
 

--- a/osxkeychain/osxkeychain_darwin_test.go
+++ b/osxkeychain/osxkeychain_darwin_test.go
@@ -75,26 +75,26 @@ func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 
 	helper := Osxkeychain{}
 	defer func() {
-		for _, te := range tests {
-			helper.Delete(te.storeURL)
+		for _, tc := range tests {
+			helper.Delete(tc.storeURL)
 		}
 	}()
 
 	// Clean store before testing.
-	for _, te := range tests {
-		helper.Delete(te.storeURL)
+	for _, tc := range tests {
+		helper.Delete(tc.storeURL)
 	}
 
-	for _, te := range tests {
-		c := &credentials.Credentials{ServerURL: te.storeURL, Username: "hello", Secret: "world"}
+	for _, tc := range tests {
+		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
 		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", te.storeURL, err)
+			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
 			continue
 		}
-		if _, _, err := helper.Get(te.readURL); err != nil {
-			t.Errorf("Error: failed to read secret for URL %q using %q", te.storeURL, te.readURL)
+		if _, _, err := helper.Get(tc.readURL); err != nil {
+			t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(te.storeURL)
+		helper.Delete(tc.storeURL)
 	}
 }
 
@@ -118,7 +118,7 @@ func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 		{"https://foobar.docker.io:1234", "https://foobar.docker.io:5678"},
 
 		// non-matching ports TODO is this desired behavior? The other way round does work
-		//{"https://foobar.docker.io", "https://foobar.docker.io:5678"},
+		// {"https://foobar.docker.io", "https://foobar.docker.io:5678"},
 
 		// non-matching paths
 		{"https://foobar.docker.io:1234/one/two", "https://foobar.docker.io:1234/five/six"},
@@ -126,26 +126,26 @@ func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 
 	helper := Osxkeychain{}
 	defer func() {
-		for _, te := range tests {
-			helper.Delete(te.storeURL)
+		for _, tc := range tests {
+			helper.Delete(tc.storeURL)
 		}
 	}()
 
 	// Clean store before testing.
-	for _, te := range tests {
-		helper.Delete(te.storeURL)
+	for _, tc := range tests {
+		helper.Delete(tc.storeURL)
 	}
 
-	for _, te := range tests {
-		c := &credentials.Credentials{ServerURL: te.storeURL, Username: "hello", Secret: "world"}
+	for _, tc := range tests {
+		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
 		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", te.storeURL, err)
+			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
 			continue
 		}
-		if _, _, err := helper.Get(te.readURL); err == nil {
-			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", te.storeURL, te.readURL)
+		if _, _, err := helper.Get(tc.readURL); err == nil {
+			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(te.storeURL)
+		helper.Delete(tc.storeURL)
 	}
 }
 
@@ -167,39 +167,39 @@ func TestOSXKeychainHelperStoreRetrieve(t *testing.T) {
 
 	helper := Osxkeychain{}
 	defer func() {
-		for _, te := range tests {
-			helper.Delete(te.url)
+		for _, tc := range tests {
+			helper.Delete(tc.url)
 		}
 	}()
 
 	// Clean store before testing.
-	for _, te := range tests {
-		helper.Delete(te.url)
+	for _, tc := range tests {
+		helper.Delete(tc.url)
 	}
 
 	// Note that we don't delete between individual tests here, to verify that
 	// subsequent stores/overwrites don't affect storing / retrieving secrets.
-	for i, te := range tests {
+	for i, tc := range tests {
 		c := &credentials.Credentials{
-			ServerURL: te.url,
+			ServerURL: tc.url,
 			Username:  fmt.Sprintf("user-%d", i),
 			Secret:    fmt.Sprintf("secret-%d", i),
 		}
 
 		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL: %s: %s", te.url, err)
+			t.Errorf("Error: failed to store secret for URL: %s: %s", tc.url, err)
 			continue
 		}
-		user, secret, err := helper.Get(te.url)
+		user, secret, err := helper.Get(tc.url)
 		if err != nil {
-			t.Errorf("Error: failed to read secret for URL %q: %s", te.url, err)
+			t.Errorf("Error: failed to read secret for URL %q: %s", tc.url, err)
 			continue
 		}
 		if user != c.Username {
-			t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, te.url)
+			t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, tc.url)
 		}
 		if secret != c.Secret {
-			t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, te.url)
+			t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, tc.url)
 		}
 	}
 }

--- a/osxkeychain/osxkeychain_darwin_test.go
+++ b/osxkeychain/osxkeychain_darwin_test.go
@@ -82,15 +82,19 @@ func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 	}
 
 	helper := Osxkeychain{}
-	defer func() {
+	t.Cleanup(func() {
 		for _, tc := range tests {
-			helper.Delete(tc.storeURL)
+			if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("cleanup: failed to delete '%s': %v", tc.storeURL, err)
+			}
 		}
-	}()
+	})
 
 	// Clean store before testing.
 	for _, tc := range tests {
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("prepare: failed to delete '%s': %v", tc.storeURL, err)
+		}
 	}
 
 	for _, tc := range tests {
@@ -102,7 +106,9 @@ func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 		if _, _, err := helper.Get(tc.readURL); err != nil {
 			t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -149,15 +155,19 @@ func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 	}
 
 	helper := Osxkeychain{}
-	defer func() {
+	t.Cleanup(func() {
 		for _, tc := range tests {
-			helper.Delete(tc.storeURL)
+			if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("cleanup: failed to delete '%s': %v", tc.storeURL, err)
+			}
 		}
-	}()
+	})
 
 	// Clean store before testing.
 	for _, tc := range tests {
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("prepare: failed to delete '%s': %v", tc.storeURL, err)
+		}
 	}
 
 	for _, tc := range tests {
@@ -169,7 +179,9 @@ func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 		if _, _, err := helper.Get(tc.readURL); err == nil {
 			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -190,15 +202,19 @@ func TestOSXKeychainHelperStoreRetrieve(t *testing.T) {
 	}
 
 	helper := Osxkeychain{}
-	defer func() {
+	t.Cleanup(func() {
 		for _, tc := range tests {
-			helper.Delete(tc.url)
+			if err := helper.Delete(tc.url); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("cleanup: failed to delete '%s': %v", tc.url, err)
+			}
 		}
-	}()
+	})
 
 	// Clean store before testing.
 	for _, tc := range tests {
-		helper.Delete(tc.url)
+		if err := helper.Delete(tc.url); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("prepare: failed to delete '%s': %v", tc.url, err)
+		}
 	}
 
 	// Note that we don't delete between individual tests here, to verify that

--- a/osxkeychain/osxkeychain_darwin_test.go
+++ b/osxkeychain/osxkeychain_darwin_test.go
@@ -60,17 +60,25 @@ func TestOSXKeychainHelper(t *testing.T) {
 // through variations on the URL
 func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 	tests := []struct {
+		doc      string
 		storeURL string
 		readURL  string
 	}{
-		// stored with port, retrieved without
-		{"https://foobar.docker.io:2376", "https://foobar.docker.io"},
-
-		// stored as https, retrieved without scheme
-		{"https://foobar.docker.io:2376", "foobar.docker.io"},
-
-		// stored with path, retrieved without
-		{"https://foobar.docker.io:1234/one/two", "https://foobar.docker.io:1234"},
+		{
+			doc:      "stored with port, retrieved without",
+			storeURL: "https://foobar.docker.io:2376",
+			readURL:  "https://foobar.docker.io",
+		},
+		{
+			doc:      "stored as https, retrieved without scheme",
+			storeURL: "https://foobar.docker.io:2376",
+			readURL:  "foobar.docker.io",
+		},
+		{
+			doc:      "stored with path, retrieved without",
+			storeURL: "https://foobar.docker.io:1234/one/two",
+			readURL:  "https://foobar.docker.io:1234",
+		},
 	}
 
 	helper := Osxkeychain{}
@@ -102,26 +110,42 @@ func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 // returned.
 func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 	tests := []struct {
+		doc      string
 		storeURL string
 		readURL  string
 	}{
-		// stored as https, retrieved using http
-		{"https://foobar.docker.io:2376", "http://foobar.docker.io:2376"},
-
-		// stored as http, retrieved using https
-		{"http://foobar.docker.io:2376", "https://foobar.docker.io:2376"},
-
-		// same: stored as http, retrieved without a scheme specified (hence, using the default https://)
-		{"http://foobar.docker.io", "foobar.docker.io:5678"},
-
-		// non-matching ports
-		{"https://foobar.docker.io:1234", "https://foobar.docker.io:5678"},
-
-		// non-matching ports TODO is this desired behavior? The other way round does work
-		// {"https://foobar.docker.io", "https://foobar.docker.io:5678"},
-
-		// non-matching paths
-		{"https://foobar.docker.io:1234/one/two", "https://foobar.docker.io:1234/five/six"},
+		{
+			doc:      "stored as https, retrieved using http",
+			storeURL: "https://foobar.docker.io:2376",
+			readURL:  "http://foobar.docker.io:2376",
+		},
+		{
+			doc:      "stored as http, retrieved using https",
+			storeURL: "http://foobar.docker.io:2376",
+			readURL:  "https://foobar.docker.io:2376",
+		},
+		{
+			// stored as http, retrieved without a scheme specified (hence, using the default https://)
+			doc:      "stored as http, retrieved without scheme",
+			storeURL: "http://foobar.docker.io",
+			readURL:  "foobar.docker.io:5678",
+		},
+		{
+			doc:      "non-matching ports",
+			storeURL: "https://foobar.docker.io:1234",
+			readURL:  "https://foobar.docker.io:5678",
+		},
+		// TODO: is this desired behavior? The other way round does work
+		// {
+		// 	doc:      "non-matching ports (stored without port)",
+		// 	storeURL: "https://foobar.docker.io",
+		// 	readURL:  "https://foobar.docker.io:5678",
+		// },
+		{
+			doc:      "non-matching paths",
+			storeURL: "https://foobar.docker.io:1234/one/two",
+			readURL:  "https://foobar.docker.io:1234/five/six",
+		},
 	}
 
 	helper := Osxkeychain{}

--- a/registryurl/parse_test.go
+++ b/registryurl/parse_test.go
@@ -24,23 +24,23 @@ func TestHelperParseURL(t *testing.T) {
 		{url: "ftp://foobar.docker.io:2376", err: errors.New("unsupported scheme: ftp")},
 	}
 
-	for _, te := range tests {
-		u, err := Parse(te.url)
+	for _, tc := range tests {
+		u, err := Parse(tc.url)
 
-		if te.err == nil && err != nil {
-			t.Errorf("Error: failed to parse URL %q: %s", te.url, err)
+		if tc.err == nil && err != nil {
+			t.Errorf("Error: failed to parse URL %q: %s", tc.url, err)
 			continue
 		}
-		if te.err != nil && err == nil {
-			t.Errorf("Error: expected error %q, got none when parsing URL %q", te.err, te.url)
+		if tc.err != nil && err == nil {
+			t.Errorf("Error: expected error %q, got none when parsing URL %q", tc.err, tc.url)
 			continue
 		}
-		if te.err != nil && err.Error() != te.err.Error() {
-			t.Errorf("Error: expected error %q, got %q when parsing URL %q", te.err, err, te.url)
+		if tc.err != nil && err.Error() != tc.err.Error() {
+			t.Errorf("Error: expected error %q, got %q when parsing URL %q", tc.err, err, tc.url)
 			continue
 		}
-		if u != nil && u.String() != te.expectedURL {
-			t.Errorf("Error: expected URL: %q, but got %q for URL: %q", te.expectedURL, u.String(), te.url)
+		if u != nil && u.String() != tc.expectedURL {
+			t.Errorf("Error: expected URL: %q, but got %q for URL: %q", tc.expectedURL, u.String(), tc.url)
 		}
 	}
 }

--- a/registryurl/parse_test.go
+++ b/registryurl/parse_test.go
@@ -13,34 +13,61 @@ func TestHelperParseURL(t *testing.T) {
 		expectedURL string
 		err         error
 	}{
-		{url: "foobar.docker.io", expectedURL: "//foobar.docker.io"},
-		{url: "foobar.docker.io:2376", expectedURL: "//foobar.docker.io:2376"},
-		{url: "//foobar.docker.io:2376", expectedURL: "//foobar.docker.io:2376"},
-		{url: "http://foobar.docker.io:2376", expectedURL: "http://foobar.docker.io:2376"},
-		{url: "https://foobar.docker.io:2376", expectedURL: "https://foobar.docker.io:2376"},
-		{url: "https://foobar.docker.io:2376/some/path", expectedURL: "https://foobar.docker.io:2376/some/path"},
-		{url: "https://foobar.docker.io:2376/some/other/path?foo=bar", expectedURL: "https://foobar.docker.io:2376/some/other/path"},
-		{url: "/foobar.docker.io", err: errors.New("no hostname in URL")},
-		{url: "ftp://foobar.docker.io:2376", err: errors.New("unsupported scheme: ftp")},
+		{
+			url:         "foobar.docker.io",
+			expectedURL: "//foobar.docker.io",
+		},
+		{
+			url:         "foobar.docker.io:2376",
+			expectedURL: "//foobar.docker.io:2376",
+		},
+		{
+			url:         "//foobar.docker.io:2376",
+			expectedURL: "//foobar.docker.io:2376",
+		},
+		{
+			url:         "http://foobar.docker.io:2376",
+			expectedURL: "http://foobar.docker.io:2376",
+		},
+		{
+			url:         "https://foobar.docker.io:2376",
+			expectedURL: "https://foobar.docker.io:2376",
+		},
+		{
+			url:         "https://foobar.docker.io:2376/some/path",
+			expectedURL: "https://foobar.docker.io:2376/some/path",
+		},
+		{
+			url:         "https://foobar.docker.io:2376/some/other/path?foo=bar",
+			expectedURL: "https://foobar.docker.io:2376/some/other/path",
+		},
+		{
+			url: "/foobar.docker.io",
+			err: errors.New("no hostname in URL"),
+		},
+		{
+			url: "ftp://foobar.docker.io:2376",
+			err: errors.New("unsupported scheme: ftp"),
+		},
 	}
 
 	for _, tc := range tests {
-		u, err := Parse(tc.url)
+		tc := tc
+		t.Run(tc.url, func(t *testing.T) {
+			u, err := Parse(tc.url)
 
-		if tc.err == nil && err != nil {
-			t.Errorf("Error: failed to parse URL %q: %s", tc.url, err)
-			continue
-		}
-		if tc.err != nil && err == nil {
-			t.Errorf("Error: expected error %q, got none when parsing URL %q", tc.err, tc.url)
-			continue
-		}
-		if tc.err != nil && err.Error() != tc.err.Error() {
-			t.Errorf("Error: expected error %q, got %q when parsing URL %q", tc.err, err, tc.url)
-			continue
-		}
-		if u != nil && u.String() != tc.expectedURL {
-			t.Errorf("Error: expected URL: %q, but got %q for URL: %q", tc.expectedURL, u.String(), tc.url)
-		}
+			if tc.err == nil && err != nil {
+				t.Fatalf("Error: failed to parse URL %q: %s", tc.url, err)
+			}
+			if tc.err != nil && err == nil {
+				t.Fatalf("Error: expected error %q, got none when parsing URL %q", tc.err, tc.url)
+			}
+			if tc.err != nil && err.Error() != tc.err.Error() {
+				t.Fatalf("Error: expected error %q, got %q when parsing URL %q", tc.err, err, tc.url)
+			}
+			if u != nil && u.String() != tc.expectedURL {
+				t.Errorf("Error: expected URL: %q, but got %q for URL: %q", tc.expectedURL, u.String(), tc.url)
+			}
+		})
 	}
 }

--- a/wincred/wincred_windows_test.go
+++ b/wincred/wincred_windows_test.go
@@ -91,17 +91,25 @@ func TestWinCredHelper(t *testing.T) {
 // through variations on the URL
 func TestWinCredHelperRetrieveAliases(t *testing.T) {
 	tests := []struct {
+		doc      string
 		storeURL string
 		readURL  string
 	}{
-		// stored with port, retrieved without
-		{"https://foobar.docker.io:2376", "https://foobar.docker.io"},
-
-		// stored as https, retrieved without scheme
-		{"https://foobar.docker.io", "foobar.docker.io"},
-
-		// stored with path, retrieved without
-		{"https://foobar.docker.io/one/two", "https://foobar.docker.io"},
+		{
+			doc:      "stored with port, retrieved without",
+			storeURL: "https://foobar.docker.io:2376",
+			readURL:  "https://foobar.docker.io",
+		},
+		{
+			doc:      "stored as https, retrieved without scheme",
+			storeURL: "https://foobar.docker.io",
+			readURL:  "foobar.docker.io",
+		},
+		{
+			doc:      "stored with path, retrieved without",
+			storeURL: "https://foobar.docker.io/one/two",
+			readURL:  "https://foobar.docker.io",
+		},
 	}
 
 	helper := Wincred{}
@@ -133,26 +141,42 @@ func TestWinCredHelperRetrieveAliases(t *testing.T) {
 // returned.
 func TestWinCredHelperRetrieveStrict(t *testing.T) {
 	tests := []struct {
+		doc      string
 		storeURL string
 		readURL  string
 	}{
-		// stored as https, retrieved using http
-		{"https://foobar.docker.io:2376", "http://foobar.docker.io:2376"},
-
-		// stored as http, retrieved using https
-		{"http://foobar.docker.io:2376", "https://foobar.docker.io:2376"},
-
-		// same: stored as http, retrieved without a scheme specified (hence, using the default https://)
-		{"http://foobar.docker.io", "foobar.docker.io:5678"},
-
-		// non-matching ports
-		{"https://foobar.docker.io:1234", "https://foobar.docker.io:5678"},
-
-		// non-matching ports TODO is this desired behavior? The other way round does work
-		// {"https://foobar.docker.io", "https://foobar.docker.io:5678"},
-
-		// non-matching paths
-		{"https://foobar.docker.io:1234/one/two", "https://foobar.docker.io:1234/five/six"},
+		{
+			doc:      "stored as https, retrieved using http",
+			storeURL: "https://foobar.docker.io:2376",
+			readURL:  "http://foobar.docker.io:2376",
+		},
+		{
+			doc:      "stored as http, retrieved using https",
+			storeURL: "http://foobar.docker.io:2376",
+			readURL:  "https://foobar.docker.io:2376",
+		},
+		{
+			// stored as http, retrieved without a scheme specified (hence, using the default https://)
+			doc:      "stored as http, retrieved without scheme",
+			storeURL: "http://foobar.docker.io",
+			readURL:  "foobar.docker.io:5678",
+		},
+		{
+			doc:      "non-matching ports",
+			storeURL: "https://foobar.docker.io:1234",
+			readURL:  "https://foobar.docker.io:5678",
+		},
+		// TODO: is this desired behavior? The other way round does work
+		// {
+		// 	doc:      "non-matching ports (stored without port)",
+		// 	storeURL: "https://foobar.docker.io",
+		// 	readURL:  "https://foobar.docker.io:5678",
+		// },
+		{
+			doc:      "non-matching paths",
+			storeURL: "https://foobar.docker.io:1234/one/two",
+			readURL:  "https://foobar.docker.io:1234/five/six",
+		},
 	}
 
 	helper := Wincred{}

--- a/wincred/wincred_windows_test.go
+++ b/wincred/wincred_windows_test.go
@@ -106,26 +106,26 @@ func TestWinCredHelperRetrieveAliases(t *testing.T) {
 
 	helper := Wincred{}
 	defer func() {
-		for _, te := range tests {
-			helper.Delete(te.storeURL)
+		for _, tc := range tests {
+			helper.Delete(tc.storeURL)
 		}
 	}()
 
 	// Clean store before testing.
-	for _, te := range tests {
-		helper.Delete(te.storeURL)
+	for _, tc := range tests {
+		helper.Delete(tc.storeURL)
 	}
 
-	for _, te := range tests {
-		c := &credentials.Credentials{ServerURL: te.storeURL, Username: "hello", Secret: "world"}
+	for _, tc := range tests {
+		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
 		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", te.storeURL, err)
+			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
 			continue
 		}
-		if _, _, err := helper.Get(te.readURL); err != nil {
-			t.Errorf("Error: failed to read secret for URL %q using %q", te.storeURL, te.readURL)
+		if _, _, err := helper.Get(tc.readURL); err != nil {
+			t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(te.storeURL)
+		helper.Delete(tc.storeURL)
 	}
 }
 
@@ -149,7 +149,7 @@ func TestWinCredHelperRetrieveStrict(t *testing.T) {
 		{"https://foobar.docker.io:1234", "https://foobar.docker.io:5678"},
 
 		// non-matching ports TODO is this desired behavior? The other way round does work
-		//{"https://foobar.docker.io", "https://foobar.docker.io:5678"},
+		// {"https://foobar.docker.io", "https://foobar.docker.io:5678"},
 
 		// non-matching paths
 		{"https://foobar.docker.io:1234/one/two", "https://foobar.docker.io:1234/five/six"},
@@ -157,26 +157,26 @@ func TestWinCredHelperRetrieveStrict(t *testing.T) {
 
 	helper := Wincred{}
 	defer func() {
-		for _, te := range tests {
-			helper.Delete(te.storeURL)
+		for _, tc := range tests {
+			helper.Delete(tc.storeURL)
 		}
 	}()
 
 	// Clean store before testing.
-	for _, te := range tests {
-		helper.Delete(te.storeURL)
+	for _, tc := range tests {
+		helper.Delete(tc.storeURL)
 	}
 
-	for _, te := range tests {
-		c := &credentials.Credentials{ServerURL: te.storeURL, Username: "hello", Secret: "world"}
+	for _, tc := range tests {
+		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
 		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", te.storeURL, err)
+			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
 			continue
 		}
-		if _, _, err := helper.Get(te.readURL); err == nil {
-			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", te.storeURL, te.readURL)
+		if _, _, err := helper.Get(tc.readURL); err == nil {
+			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(te.storeURL)
+		helper.Delete(tc.storeURL)
 	}
 }
 
@@ -198,39 +198,39 @@ func TestWinCredHelperStoreRetrieve(t *testing.T) {
 
 	helper := Wincred{}
 	defer func() {
-		for _, te := range tests {
-			helper.Delete(te.url)
+		for _, tc := range tests {
+			helper.Delete(tc.url)
 		}
 	}()
 
 	// Clean store before testing.
-	for _, te := range tests {
-		helper.Delete(te.url)
+	for _, tc := range tests {
+		helper.Delete(tc.url)
 	}
 
 	// Note that we don't delete between individual tests here, to verify that
 	// subsequent stores/overwrites don't affect storing / retrieving secrets.
-	for i, te := range tests {
+	for i, tc := range tests {
 		c := &credentials.Credentials{
-			ServerURL: te.url,
+			ServerURL: tc.url,
 			Username:  fmt.Sprintf("user-%d", i),
 			Secret:    fmt.Sprintf("secret-%d", i),
 		}
 
 		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL: %s: %s", te.url, err)
+			t.Errorf("Error: failed to store secret for URL: %s: %s", tc.url, err)
 			continue
 		}
-		user, secret, err := helper.Get(te.url)
+		user, secret, err := helper.Get(tc.url)
 		if err != nil {
-			t.Errorf("Error: failed to read secret for URL %q: %s", te.url, err)
+			t.Errorf("Error: failed to read secret for URL %q: %s", tc.url, err)
 			continue
 		}
 		if user != c.Username {
-			t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, te.url)
+			t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, tc.url)
 		}
 		if secret != c.Secret {
-			t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, te.url)
+			t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, tc.url)
 		}
 	}
 }

--- a/wincred/wincred_windows_test.go
+++ b/wincred/wincred_windows_test.go
@@ -113,15 +113,19 @@ func TestWinCredHelperRetrieveAliases(t *testing.T) {
 	}
 
 	helper := Wincred{}
-	defer func() {
+	t.Cleanup(func() {
 		for _, tc := range tests {
-			helper.Delete(tc.storeURL)
+			if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("cleanup: failed to delete '%s': %v", tc.storeURL, err)
+			}
 		}
-	}()
+	})
 
 	// Clean store before testing.
 	for _, tc := range tests {
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("prepare: failed to delete '%s': %v", tc.storeURL, err)
+		}
 	}
 
 	for _, tc := range tests {
@@ -133,7 +137,9 @@ func TestWinCredHelperRetrieveAliases(t *testing.T) {
 		if _, _, err := helper.Get(tc.readURL); err != nil {
 			t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -180,15 +186,19 @@ func TestWinCredHelperRetrieveStrict(t *testing.T) {
 	}
 
 	helper := Wincred{}
-	defer func() {
+	t.Cleanup(func() {
 		for _, tc := range tests {
-			helper.Delete(tc.storeURL)
+			if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("cleanup: failed to delete '%s': %v", tc.storeURL, err)
+			}
 		}
-	}()
+	})
 
 	// Clean store before testing.
 	for _, tc := range tests {
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("prepare: failed to delete '%s': %v", tc.storeURL, err)
+		}
 	}
 
 	for _, tc := range tests {
@@ -200,7 +210,9 @@ func TestWinCredHelperRetrieveStrict(t *testing.T) {
 		if _, _, err := helper.Get(tc.readURL); err == nil {
 			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
 		}
-		helper.Delete(tc.storeURL)
+		if err := helper.Delete(tc.storeURL); err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -221,15 +233,19 @@ func TestWinCredHelperStoreRetrieve(t *testing.T) {
 	}
 
 	helper := Wincred{}
-	defer func() {
+	t.Cleanup(func() {
 		for _, tc := range tests {
-			helper.Delete(tc.url)
+			if err := helper.Delete(tc.url); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+				t.Errorf("cleanup: failed to delete '%s': %v", tc.url, err)
+			}
 		}
-	}()
+	})
 
 	// Clean store before testing.
 	for _, tc := range tests {
-		helper.Delete(tc.url)
+		if err := helper.Delete(tc.url); err != nil && !credentials.IsErrCredentialsNotFound(err) {
+			t.Errorf("prepare: failed to delete '%s': %v", tc.url, err)
+		}
 	}
 
 	// Note that we don't delete between individual tests here, to verify that

--- a/wincred/wincred_windows_test.go
+++ b/wincred/wincred_windows_test.go
@@ -129,17 +129,19 @@ func TestWinCredHelperRetrieveAliases(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
-		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
-			continue
-		}
-		if _, _, err := helper.Get(tc.readURL); err != nil {
-			t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
-		}
-		if err := helper.Delete(tc.storeURL); err != nil {
-			t.Error(err)
-		}
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
+			if err := helper.Add(c); err != nil {
+				t.Fatalf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
+			}
+			if _, _, err := helper.Get(tc.readURL); err != nil {
+				t.Errorf("Error: failed to read secret for URL %q using %q", tc.storeURL, tc.readURL)
+			}
+			if err := helper.Delete(tc.storeURL); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 
@@ -202,17 +204,19 @@ func TestWinCredHelperRetrieveStrict(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
-		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
-			continue
-		}
-		if _, _, err := helper.Get(tc.readURL); err == nil {
-			t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
-		}
-		if err := helper.Delete(tc.storeURL); err != nil {
-			t.Error(err)
-		}
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			c := &credentials.Credentials{ServerURL: tc.storeURL, Username: "hello", Secret: "world"}
+			if err := helper.Add(c); err != nil {
+				t.Fatalf("Error: failed to store secret for URL %q: %s", tc.storeURL, err)
+			}
+			if _, _, err := helper.Get(tc.readURL); err == nil {
+				t.Errorf("Error: managed to read secret for URL %q using %q, but should not be able to", tc.storeURL, tc.readURL)
+			}
+			if err := helper.Delete(tc.storeURL); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 
@@ -251,27 +255,28 @@ func TestWinCredHelperStoreRetrieve(t *testing.T) {
 	// Note that we don't delete between individual tests here, to verify that
 	// subsequent stores/overwrites don't affect storing / retrieving secrets.
 	for i, tc := range tests {
-		c := &credentials.Credentials{
-			ServerURL: tc.url,
-			Username:  fmt.Sprintf("user-%d", i),
-			Secret:    fmt.Sprintf("secret-%d", i),
-		}
+		tc := tc
+		t.Run(tc.url, func(t *testing.T) {
+			c := &credentials.Credentials{
+				ServerURL: tc.url,
+				Username:  fmt.Sprintf("user-%d", i),
+				Secret:    fmt.Sprintf("secret-%d", i),
+			}
 
-		if err := helper.Add(c); err != nil {
-			t.Errorf("Error: failed to store secret for URL: %s: %s", tc.url, err)
-			continue
-		}
-		user, secret, err := helper.Get(tc.url)
-		if err != nil {
-			t.Errorf("Error: failed to read secret for URL %q: %s", tc.url, err)
-			continue
-		}
-		if user != c.Username {
-			t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, tc.url)
-		}
-		if secret != c.Secret {
-			t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, tc.url)
-		}
+			if err := helper.Add(c); err != nil {
+				t.Fatalf("Error: failed to store secret for URL: %s: %s", tc.url, err)
+			}
+			user, secret, err := helper.Get(tc.url)
+			if err != nil {
+				t.Fatalf("Error: failed to read secret for URL %q: %s", tc.url, err)
+			}
+			if user != c.Username {
+				t.Errorf("Error: expected username %s, got username %s for URL: %s", c.Username, user, tc.url)
+			}
+			if secret != c.Secret {
+				t.Errorf("Error: expected secret %s, got secret %s for URL: %s", c.Secret, secret, tc.url)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- [x] depends on https://github.com/docker/docker-credential-helpers/pull/278

See individual commits for details