### PR TITLE
osxkeychain: Delete(): return typed errors

### DIFF
--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -93,15 +93,14 @@ func (h Osxkeychain) Get(serverURL string) (string, string, error) {
 	errMsg := C.keychain_get(s, &usernameLen, &username, &secretLen, &secret)
 	if errMsg != nil {
 		defer C.free(unsafe.Pointer(errMsg))
-		goMsg := C.GoString(errMsg)
-		if goMsg == errCredentialsNotFound {
+		switch goMsg := C.GoString(errMsg); goMsg {
+		case errCredentialsNotFound:
 			return "", "", credentials.NewErrCredentialsNotFound()
-		}
-		if goMsg == errInteractionNotAllowed {
+		case errInteractionNotAllowed:
 			return "", "", ErrInteractionNotAllowed
+		default:
+			return "", "", errors.New(goMsg)
 		}
-
-		return "", "", errors.New(goMsg)
 	}
 
 	user := C.GoStringN(username, C.int(usernameLen))
@@ -124,15 +123,14 @@ func (h Osxkeychain) List() (map[string]string, error) {
 	defer C.freeListData(&acctsC, listLenC)
 	if errMsg != nil {
 		defer C.free(unsafe.Pointer(errMsg))
-		goMsg := C.GoString(errMsg)
-		if goMsg == errCredentialsNotFound {
+		switch goMsg := C.GoString(errMsg); goMsg {
+		case errCredentialsNotFound:
 			return make(map[string]string), nil
-		}
-		if goMsg == errInteractionNotAllowed {
+		case errInteractionNotAllowed:
 			return nil, ErrInteractionNotAllowed
+		default:
+			return nil, errors.New(goMsg)
 		}
-
-		return nil, errors.New(goMsg)
 	}
 
 	var listLen int

--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -34,7 +34,7 @@ type Osxkeychain struct{}
 
 // Add adds new credentials to the keychain.
 func (h Osxkeychain) Add(creds *credentials.Credentials) error {
-	h.Delete(creds.ServerURL)
+	_ = h.Delete(creds.ServerURL) // ignore errors as existing credential may not exist.
 
 	s, err := splitServer(creds.ServerURL)
 	if err != nil {

--- a/osxkeychain/osxkeychain_darwin_test.go
+++ b/osxkeychain/osxkeychain_darwin_test.go
@@ -205,9 +205,14 @@ func TestOSXKeychainHelperStoreRetrieve(t *testing.T) {
 }
 
 func TestMissingCredentials(t *testing.T) {
+	const nonExistingCred = "https://adsfasdf.invalid/asdfsdddd"
 	helper := Osxkeychain{}
-	_, _, err := helper.Get("https://adsfasdf.wrewerwer.com/asdfsdddd")
+	_, _, err := helper.Get(nonExistingCred)
 	if !credentials.IsErrCredentialsNotFound(err) {
-		t.Fatalf("expected ErrCredentialsNotFound, got %v", err)
+		t.Errorf("expected ErrCredentialsNotFound, got %v", err)
+	}
+	err = helper.Delete(nonExistingCred)
+	if !credentials.IsErrCredentialsNotFound(err) {
+		t.Errorf("expected ErrCredentialsNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
This allows a Delete for non-existing credentials to be handled.