### PR TITLE
osxkeychain: match min macos version for xx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,7 @@ RUN --mount=type=bind,target=. \
     --mount=type=bind,source=/tmp/.version,target=/tmp/.version,from=version \
     --mount=type=bind,source=/tmp/.revision,target=/tmp/.revision,from=version <<EOT
   set -ex
+  export MACOSX_VERSION_MIN=$(make print-MACOSX_DEPLOYMENT_TARGET)
   xx-go --wrap
   go install std
   make build-osxkeychain build-pass PACKAGE=$PACKAGE VERSION=$(cat /tmp/.version) REVISION=$(cat /tmp/.revision) DESTDIR=/out

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ BUILDX_CMD ?= docker buildx
 DESTDIR ?= ./bin/build
 COVERAGEDIR ?= ./bin/coverage
 
+# 10.11 is the minimum supported version for osxkeychain
+export MACOSX_DEPLOYMENT_TARGET = 10.11
+ifeq "$(shell go env GOOS)" "darwin"
+	export CGO_CFLAGS = -mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
+endif
+
 .PHONY: all
 all: cross
 
@@ -75,3 +81,6 @@ vendor:
 	rm -rf ./vendor
 	cp -R "$($@_TMP_OUT)"/* .
 	rm -rf "$($@_TMP_OUT)"
+
+.PHONY: print-%
+print-%: ; @echo $($*)

--- a/osxkeychain/osxkeychain_darwin.go
+++ b/osxkeychain/osxkeychain_darwin.go
@@ -1,8 +1,8 @@
 package osxkeychain
 
 /*
-#cgo CFLAGS: -x objective-c -mmacosx-version-min=10.11
-#cgo LDFLAGS: -framework Security -framework Foundation -mmacosx-version-min=10.11
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Security -framework Foundation
 
 #include "osxkeychain_darwin.h"
 #include <stdlib.h>


### PR DESCRIPTION
partially solves #280 

`xx` sets a minimal macos version if not set through `MACOSX_VERSION_MIN` env var: https://github.com/tonistiigi/xx/blob/3d00d096c8bf894ec29bae5caa5aea81d9c187a5/base/xx-info#L203-L209