### PR TITLE
readme: install emulators when building with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Go to the [Releases](https://github.com/docker/docker-credential-helpers/release
 You can build the credential helpers using Docker:
 
 ```shell
+# install emulators
+$ docker run --privileged --rm tonistiigi/binfmt --install all
+
 # create builder
 $ docker buildx create --use
 


### PR DESCRIPTION
fixes https://github.com/docker/docker-credential-helpers/issues/260

Adds instruction to install emulators to be able to build with Docker. We don't encounter this issue on Docker Desktop as emulators are already installed. On CI we already install emulators with qemu action: https://github.com/docker/docker-credential-helpers/blob/bdd92dd0d34762226ed61e31e940a22fc03ed801/.github/workflows/build.yml#L137-L139