### PR TITLE
pass: fix interpolation of $PASSWORD_STORE_DIR, and use os.UserHomeDir()

### DIFF
--- a/pass/pass.go
+++ b/pass/pass.go
@@ -104,11 +104,10 @@ func (p Pass) Delete(serverURL string) error {
 }
 
 func getPassDir() string {
-	passDir := "$HOME/.password-store"
-	if envDir := os.Getenv("PASSWORD_STORE_DIR"); envDir != "" {
-		passDir = envDir
+	if passDir := os.Getenv("PASSWORD_STORE_DIR"); passDir != "" {
+		return passDir
 	}
-	return os.ExpandEnv(passDir)
+	return os.ExpandEnv("$HOME/.password-store")
 }
 
 // listPassDir lists all the contents of a directory in the password store.

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -107,7 +108,8 @@ func getPassDir() string {
 	if passDir := os.Getenv("PASSWORD_STORE_DIR"); passDir != "" {
 		return passDir
 	}
-	return os.ExpandEnv("$HOME/.password-store")
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".password-store")
 }
 
 // listPassDir lists all the contents of a directory in the password store.


### PR DESCRIPTION
- relates to https://github.com/docker/docker-credential-helpers/pull/109

commit a13ff500176e7570239691424050fb46b0a7f05b (https://github.com/docker/docker-credential-helpers/pull/109) simplified the handling of env-vars in getPassDir(), but moved interpolation of env-vars to the end of the function.

As a result, a custom path passed through `$PASSWORD_STORE_DIR` would now be interpolated, instead of taken as-is. For example;

    PASSWORD_STORE_DIR=$PWD/world

Would now interpolate `$PWD`, instead of using a literal `$PWD`.

This patch changes the logic to only expand env-vars for the default location.

### pass: make home-dir resolution platform agnostic

Use stdlib's `os.UserHomeDir()` instead of depending only on `$HOME`. Note that
this does not yet does nss lookups for situations where `$HOME` / `$USERPROFILE`
is not set.
