### PR TITLE
credentials: improve errors and error-handling

### DIFF
--- a/credentials/error.go
+++ b/credentials/error.go
@@ -1,5 +1,7 @@
 package credentials
 
+import "errors"
+
 const (
 	// ErrCredentialsNotFound standardizes the not found error, so every helper returns
 	// the same message and docker can handle it properly.
@@ -30,8 +32,8 @@ func NewErrCredentialsNotFound() error {
 // IsErrCredentialsNotFound returns true if the error
 // was caused by not having a set of credentials in a store.
 func IsErrCredentialsNotFound(err error) bool {
-	_, ok := err.(errCredentialsNotFound)
-	return ok
+	var target errCredentialsNotFound
+	return errors.As(err, &target)
 }
 
 // IsErrCredentialsNotFoundMessage returns true if the error
@@ -78,8 +80,8 @@ func NewErrCredentialsMissingUsername() error {
 // IsCredentialsMissingServerURL returns true if the error
 // was an errCredentialsMissingServerURL.
 func IsCredentialsMissingServerURL(err error) bool {
-	_, ok := err.(errCredentialsMissingServerURL)
-	return ok
+	var target errCredentialsMissingServerURL
+	return errors.As(err, &target)
 }
 
 // IsCredentialsMissingServerURLMessage checks for an
@@ -91,8 +93,8 @@ func IsCredentialsMissingServerURLMessage(err string) bool {
 // IsCredentialsMissingUsername returns true if the error
 // was an errCredentialsMissingUsername.
 func IsCredentialsMissingUsername(err error) bool {
-	_, ok := err.(errCredentialsMissingUsername)
-	return ok
+	var target errCredentialsMissingUsername
+	return errors.As(err, &target)
 }
 
 // IsCredentialsMissingUsernameMessage checks for an

--- a/credentials/error.go
+++ b/credentials/error.go
@@ -23,6 +23,11 @@ func (errCredentialsNotFound) Error() string {
 	return errCredentialsNotFoundMessage
 }
 
+// NotFound implements the [ErrNotFound][errdefs.ErrNotFound] interface.
+//
+// [errdefs.ErrNotFound]: https://pkg.go.dev/github.com/docker/docker@v24.0.1+incompatible/errdefs#ErrNotFound
+func (errCredentialsNotFound) NotFound() {}
+
 // NewErrCredentialsNotFound creates a new error
 // for when the credentials are not in the store.
 func NewErrCredentialsNotFound() error {
@@ -55,6 +60,12 @@ func (errCredentialsMissingServerURL) Error() string {
 	return errCredentialsMissingServerURLMessage
 }
 
+// InvalidParameter implements the [ErrInvalidParameter][errdefs.ErrInvalidParameter]
+// interface.
+//
+// [errdefs.ErrInvalidParameter]: https://pkg.go.dev/github.com/docker/docker@v24.0.1+incompatible/errdefs#ErrInvalidParameter
+func (errCredentialsMissingServerURL) InvalidParameter() {}
+
 // errCredentialsMissingUsername represents an error raised
 // when the credentials object has no username or when no
 // username is provided to a credentials operation requiring
@@ -64,6 +75,12 @@ type errCredentialsMissingUsername struct{}
 func (errCredentialsMissingUsername) Error() string {
 	return errCredentialsMissingUsernameMessage
 }
+
+// InvalidParameter implements the [ErrInvalidParameter][errdefs.ErrInvalidParameter]
+// interface.
+//
+// [errdefs.ErrInvalidParameter]: https://pkg.go.dev/github.com/docker/docker@v24.0.1+incompatible/errdefs#ErrInvalidParameter
+func (errCredentialsMissingUsername) InvalidParameter() {}
 
 // NewErrCredentialsMissingServerURL creates a new error for
 // errCredentialsMissingServerURL.


### PR DESCRIPTION
### credentials: use errors.Is() to match error-types


### credentials: implement errdefs types for typed errors

This allows for checking the error-type returned to be matched with the errdefs utilities.