### PR TITLE
use designated domains in tests (RFC2606) (step 1)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	validServerAddress   = "https://index.docker.io/v1"
+	validServerAddress   = "https://registry.example.com/v1"
 	validUsername        = "linus"
 	validServerAddress2  = "https://example.com:5002"
 	invalidServerAddress = "https://foobar.example.com"
-	missingCredsAddress  = "https://missing.docker.io/v1"
+	missingCredsAddress  = "https://missing.example.com/v1"
 )
 
 var errProgramExited = fmt.Errorf("exited 1")

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -42,7 +42,7 @@ func (m *memoryStore) List() (map[string]string, error) {
 }
 
 func TestStore(t *testing.T) {
-	const serverURL = "https://index.docker.io/v1/"
+	const serverURL = "https://registry.example.com/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -95,7 +95,7 @@ func TestStoreMissingServerURL(t *testing.T) {
 
 func TestStoreMissingUsername(t *testing.T) {
 	creds := &Credentials{
-		ServerURL: "https://index.docker.io/v1/",
+		ServerURL: "https://registry.example.com/v1/",
 		Username:  "",
 		Secret:    "bar",
 	}
@@ -114,7 +114,7 @@ func TestStoreMissingUsername(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	const serverURL = "https://index.docker.io/v1/"
+	const serverURL = "https://registry.example.com/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -156,7 +156,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetMissingServerURL(t *testing.T) {
-	const serverURL = "https://index.docker.io/v1/"
+	const serverURL = "https://registry.example.com/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -182,7 +182,7 @@ func TestGetMissingServerURL(t *testing.T) {
 }
 
 func TestErase(t *testing.T) {
-	const serverURL = "https://index.docker.io/v1/"
+	const serverURL = "https://registry.example.com/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",
@@ -211,7 +211,7 @@ func TestErase(t *testing.T) {
 }
 
 func TestEraseMissingServerURL(t *testing.T) {
-	const serverURL = "https://index.docker.io/v1/"
+	const serverURL = "https://registry.example.com/v1/"
 	creds := &Credentials{
 		ServerURL: serverURL,
 		Username:  "foo",

--- a/osxkeychain/osxkeychain_test.go
+++ b/osxkeychain/osxkeychain_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestOSXKeychainHelper(t *testing.T) {
 	creds := &credentials.Credentials{
-		ServerURL: "https://foobar.docker.io:2376/v1",
+		ServerURL: "https://foobar.example.com:2376/v1",
 		Username:  "foobar",
 		Secret:    "foobarbaz",
 	}
 	creds1 := &credentials.Credentials{
-		ServerURL: "https://foobar.docker.io:2376/v2",
+		ServerURL: "https://foobar.example.com:2376/v2",
 		Username:  "foobarbaz",
 		Secret:    "foobar",
 	}
@@ -68,18 +68,18 @@ func TestOSXKeychainHelperRetrieveAliases(t *testing.T) {
 	}{
 		{
 			doc:      "stored with port, retrieved without",
-			storeURL: "https://foobar.docker.io:2376",
-			readURL:  "https://foobar.docker.io",
+			storeURL: "https://foobar.example.com:2376",
+			readURL:  "https://foobar.example.com",
 		},
 		{
 			doc:      "stored as https, retrieved without scheme",
-			storeURL: "https://foobar.docker.io:2376",
-			readURL:  "foobar.docker.io",
+			storeURL: "https://foobar.example.com:2376",
+			readURL:  "foobar.example.com",
 		},
 		{
 			doc:      "stored with path, retrieved without",
-			storeURL: "https://foobar.docker.io:1234/one/two",
-			readURL:  "https://foobar.docker.io:1234",
+			storeURL: "https://foobar.example.com:1234/one/two",
+			readURL:  "https://foobar.example.com:1234",
 		},
 	}
 
@@ -126,35 +126,35 @@ func TestOSXKeychainHelperRetrieveStrict(t *testing.T) {
 	}{
 		{
 			doc:      "stored as https, retrieved using http",
-			storeURL: "https://foobar.docker.io:2376",
-			readURL:  "http://foobar.docker.io:2376",
+			storeURL: "https://foobar.example.com:2376",
+			readURL:  "http://foobar.example.com:2376",
 		},
 		{
 			doc:      "stored as http, retrieved using https",
-			storeURL: "http://foobar.docker.io:2376",
-			readURL:  "https://foobar.docker.io:2376",
+			storeURL: "http://foobar.example.com:2376",
+			readURL:  "https://foobar.example.com:2376",
 		},
 		{
 			// stored as http, retrieved without a scheme specified (hence, using the default https://)
 			doc:      "stored as http, retrieved without scheme",
-			storeURL: "http://foobar.docker.io",
-			readURL:  "foobar.docker.io:5678",
+			storeURL: "http://foobar.example.com",
+			readURL:  "foobar.example.com:5678",
 		},
 		{
 			doc:      "non-matching ports",
-			storeURL: "https://foobar.docker.io:1234",
-			readURL:  "https://foobar.docker.io:5678",
+			storeURL: "https://foobar.example.com:1234",
+			readURL:  "https://foobar.example.com:5678",
 		},
 		// TODO: is this desired behavior? The other way round does work
 		// {
 		// 	doc:      "non-matching ports (stored without port)",
-		// 	storeURL: "https://foobar.docker.io",
-		// 	readURL:  "https://foobar.docker.io:5678",
+		// 	storeURL: "https://foobar.example.com",
+		// 	readURL:  "https://foobar.example.com:5678",
 		// },
 		{
 			doc:      "non-matching paths",
-			storeURL: "https://foobar.docker.io:1234/one/two",
-			readURL:  "https://foobar.docker.io:1234/five/six",
+			storeURL: "https://foobar.example.com:1234/one/two",
+			readURL:  "https://foobar.example.com:1234/five/six",
 		},
 	}
 
@@ -197,14 +197,14 @@ func TestOSXKeychainHelperStoreRetrieve(t *testing.T) {
 	tests := []struct {
 		url string
 	}{
-		{url: "foobar.docker.io"},
-		{url: "foobar.docker.io:2376"},
-		{url: "//foobar.docker.io:2376"},
-		{url: "https://foobar.docker.io:2376"},
-		{url: "http://foobar.docker.io:2376"},
-		{url: "https://foobar.docker.io:2376/some/path"},
-		{url: "https://foobar.docker.io:2376/some/other/path"},
-		{url: "https://foobar.docker.io:2376/some/other/path?foo=bar"},
+		{url: "foobar.example.com"},
+		{url: "foobar.example.com:2376"},
+		{url: "//foobar.example.com:2376"},
+		{url: "https://foobar.example.com:2376"},
+		{url: "http://foobar.example.com:2376"},
+		{url: "https://foobar.example.com:2376/some/path"},
+		{url: "https://foobar.example.com:2376/some/other/path"},
+		{url: "https://foobar.example.com:2376/some/other/path?foo=bar"},
 	}
 
 	helper := Osxkeychain{}

--- a/pass/pass_test.go
+++ b/pass/pass_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPassHelper(t *testing.T) {
 	creds := &credentials.Credentials{
-		ServerURL: "https://foobar.docker.io:2376/v1",
+		ServerURL: "https://foobar.example.com:2376/v1",
 		Username:  "nothing",
 		Secret:    "isthebestmeshuggahalbum",
 	}
@@ -54,12 +54,12 @@ func TestPassHelperCheckInit(t *testing.T) {
 func TestPassHelperList(t *testing.T) {
 	creds := []*credentials.Credentials{
 		{
-			ServerURL: "https://foobar.docker.io:2376/v1",
+			ServerURL: "https://foobar.example.com:2376/v1",
 			Username:  "foo",
 			Secret:    "isthebestmeshuggahalbum",
 		},
 		{
-			ServerURL: "https://foobar.docker.io:2375/v1",
+			ServerURL: "https://foobar.example.com:2375/v1",
 			Username:  "bar",
 			Secret:    "isthebestmeshuggahalbum",
 		},

--- a/registryurl/parse_test.go
+++ b/registryurl/parse_test.go
@@ -14,39 +14,39 @@ func TestHelperParseURL(t *testing.T) {
 		err         error
 	}{
 		{
-			url:         "foobar.docker.io",
-			expectedURL: "//foobar.docker.io",
+			url:         "foobar.example.com",
+			expectedURL: "//foobar.example.com",
 		},
 		{
-			url:         "foobar.docker.io:2376",
-			expectedURL: "//foobar.docker.io:2376",
+			url:         "foobar.example.com:2376",
+			expectedURL: "//foobar.example.com:2376",
 		},
 		{
-			url:         "//foobar.docker.io:2376",
-			expectedURL: "//foobar.docker.io:2376",
+			url:         "//foobar.example.com:2376",
+			expectedURL: "//foobar.example.com:2376",
 		},
 		{
-			url:         "http://foobar.docker.io:2376",
-			expectedURL: "http://foobar.docker.io:2376",
+			url:         "http://foobar.example.com:2376",
+			expectedURL: "http://foobar.example.com:2376",
 		},
 		{
-			url:         "https://foobar.docker.io:2376",
-			expectedURL: "https://foobar.docker.io:2376",
+			url:         "https://foobar.example.com:2376",
+			expectedURL: "https://foobar.example.com:2376",
 		},
 		{
-			url:         "https://foobar.docker.io:2376/some/path",
-			expectedURL: "https://foobar.docker.io:2376/some/path",
+			url:         "https://foobar.example.com:2376/some/path",
+			expectedURL: "https://foobar.example.com:2376/some/path",
 		},
 		{
-			url:         "https://foobar.docker.io:2376/some/other/path?foo=bar",
-			expectedURL: "https://foobar.docker.io:2376/some/other/path",
+			url:         "https://foobar.example.com:2376/some/other/path?foo=bar",
+			expectedURL: "https://foobar.example.com:2376/some/other/path",
 		},
 		{
-			url: "/foobar.docker.io",
+			url: "/foobar.example.com",
 			err: errors.New("no hostname in URL"),
 		},
 		{
-			url: "ftp://foobar.docker.io:2376",
+			url: "ftp://foobar.example.com:2376",
 			err: errors.New("unsupported scheme: ftp"),
 		},
 	}

--- a/secretservice/secretservice_test.go
+++ b/secretservice/secretservice_test.go
@@ -13,7 +13,7 @@ func TestSecretServiceHelper(t *testing.T) {
 	t.Skip("test requires gnome-keyring but travis CI doesn't have it")
 
 	creds := &credentials.Credentials{
-		ServerURL: "https://foobar.docker.io:2376/v1",
+		ServerURL: "https://foobar.example.com:2376/v1",
 		Username:  "foobar",
 		Secret:    "foobarbaz",
 	}


### PR DESCRIPTION
updates all tests, except for wincreds (handled in https://github.com/docker/docker-credential-helpers/pull/274)