### PR TITLE
pass: return correct error, and ignore empty stores on list

### DIFF
--- a/pass/pass.go
+++ b/pass/pass.go
@@ -158,7 +158,7 @@ func (p Pass) Get(serverURL string) (string, string, error) {
 	}
 
 	if len(usernames) < 1 {
-		return "", "", fmt.Errorf("no usernames for %s", serverURL)
+		return "", "", credentials.NewErrCredentialsNotFound()
 	}
 
 	actual := strings.TrimSuffix(usernames[0].Name(), ".gpg")
@@ -191,7 +191,7 @@ func (p Pass) List() (map[string]string, error) {
 		}
 
 		if len(usernames) < 1 {
-			return nil, fmt.Errorf("no usernames for %s", serverURL)
+			continue
 		}
 
 		resp[string(serverURL)] = strings.TrimSuffix(usernames[0].Name(), ".gpg")


### PR DESCRIPTION
commit 2fc2313bb1a9608195bb2a7624983b52901d4c73 changed the errors returned by the pass credentials-helper to use a errCredentialsNotFound. This error string is used in the client to distinguish a "not found" error from other errors. (see [client.Get][1]).

However, there were additional second code-paths that returned a custom error, which would not be detected as a "not found" error, resulting in an error when logging out;

    Removing login credentials for https://index.docker.io/v1/
    WARNING: could not erase credentials:
    https://index.docker.io/v1/: error erasing credentials - err: exit status 1, out: `error getting credentials - err: exit status 1, out: `no usernames for https://index.docker.io/v1/``

This patch:

- updates Pass.Get() to return a errCredentialsNotFound if no credentials were found
- updates Pass.List() to not return an error if any of the domains had no credentials stored.

[1]: https://github.com/docker/docker-credential-helpers/blob/73b9e5d51f8dc9f598e08a0f2171c5d5a828e76b/client/client.go#L51-L55


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix "could not erase credentials" when trying to log out and no credentials were present
```


**- A picture of a cute animal (not mandatory but encouraged)**

