### PR TITLE
pass: add utilities for encoding/decoding serverURL

### DIFF
--- a/pass/pass_test.go
+++ b/pass/pass_test.go
@@ -3,7 +3,6 @@
 package pass
 
 import (
-	"encoding/base64"
 	"os"
 	"path"
 	"strings"
@@ -152,7 +151,7 @@ func TestPassHelperWithEmptyServer(t *testing.T) {
 			}
 		} else {
 			// No credentials; create an empty directory for this server.
-			serverURL := base64.URLEncoding.EncodeToString([]byte(cred.ServerURL))
+			serverURL := encodeServerURL(cred.ServerURL)
 			p := path.Join(getPassDir(), PASS_FOLDER, serverURL)
 			if err := os.Mkdir(p, 0o755); err != nil {
 				t.Error(err)


### PR DESCRIPTION
While the implementation of these is fairly trivial, we want them to remain the same. This patch adds utilities to handle the encoding and decoding of the server-URLs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

