### PR TITLE
pass: Get: remove redundant stat

### DIFF
--- a/pass/pass.go
+++ b/pass/pass.go
@@ -142,15 +142,6 @@ func (p Pass) Get(serverURL string) (string, string, error) {
 	}
 
 	encoded := encodeServerURL(serverURL)
-
-	if _, err := os.Stat(path.Join(getPassDir(), PASS_FOLDER, encoded)); err != nil {
-		if os.IsNotExist(err) {
-			return "", "", credentials.NewErrCredentialsNotFound()
-		}
-
-		return "", "", err
-	}
-
 	usernames, err := listPassDir(encoded)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
listPassdir already handles "not found" errors, in which case it returns an [empty result][1]. Previously this would return a custom error, but since 1bb9aa321022b0fcf5b484fe2fc12d9cef1f4b6e (https://github.com/docker/docker-credential-helpers/pull/321), an empty result produces a `errCredentialsNotFound`, making this check redundant.

This patch removes the redundant check.

[1]: https://github.com/docker/docker-credential-helpers/blob/f64d6b131b3da07a6337dc63a882e08ce541d1c1/pass/pass.go#L118-L125



**- A picture of a cute animal (not mandatory but encouraged)**

