### PR TITLE
update to go1.23.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   DESTDIR: ./bin
-  GO_VERSION: 1.21.10
+  GO_VERSION: 1.22.11
 
 jobs:
   validate:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   DESTDIR: ./bin
-  GO_VERSION: 1.22.11
+  GO_VERSION: 1.23.6
 
 jobs:
   validate:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.21.10
+ARG GO_VERSION=1.22.11
 ARG DEBIAN_VERSION=bookworm
 
 ARG XX_VERSION=1.6.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.22.11
+ARG GO_VERSION=1.23.6
 ARG DEBIAN_VERSION=bookworm
 
 ARG XX_VERSION=1.6.1

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,17 @@ ifeq "$(shell go env GOOS)" "darwin"
 	export CGO_CFLAGS = -mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
 endif
 
+ifeq "$(shell go env GOOS)/$(shell go env GOARCH)/$(shell go env GOARM)" "linux/arm/6"
+	# Neither the CGo compiler, nor the C toolchain automatically link to
+	# libatomic when the architecture doesn't support atomic intrinsics, as is
+	# the case for arm/v6.
+	#
+	# Here's the error we get when this is not done (see https://github.com/docker/docker-credential-helpers/pull/340#issuecomment-2437593837):
+	#
+	# gcc_libinit.c:44:8: error: large atomic operation may incur significant performance penalty; the access size (4 bytes) exceeds the max lock-free size (0  bytes) [-Werror,-Watomic-alignment]
+	export CGO_LDFLAGS=-latomic
+endif
+
 .PHONY: all
 all: cross
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ COVERAGEDIR ?= ./bin/coverage
 # 10.11 is the minimum supported version for osxkeychain
 export MACOSX_DEPLOYMENT_TARGET = 10.11
 ifeq "$(shell go env GOOS)" "darwin"
-	export CGO_CFLAGS = -mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
+	export CGO_CFLAGS = -Wno-atomic-alignment -mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
+else
+	# prevent warnings; see https://github.com/docker/docker-credential-helpers/pull/340#issuecomment-2437593837
+	# gcc_libinit.c:44:8: error: large atomic operation may incur significant performance penalty; the access size (4 bytes) exceeds the max lock-free size (0  bytes) [-Werror,-Watomic-alignment]
+	export CGO_CFLAGS = -Wno-atomic-alignment
 endif
 
 ifeq "$(shell go env GOOS)/$(shell go env GOARCH)/$(shell go env GOARM)" "linux/arm/6"

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.22.11
+ARG GO_VERSION=1.23.6
 ARG DISTRO=ubuntu
 ARG SUITE=focal
 

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.21.10
+ARG GO_VERSION=1.22.11
 ARG DISTRO=ubuntu
 ARG SUITE=focal
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-  default = "1.21.10"
+  default = null
 }
 
 # Defines the output folder


### PR DESCRIPTION
### Makefile: set CGO_LDFLAGS=-latomic on arm/v6

Compiling with Go >= 1.22 on arm/v6 is failing with the following error
message:

27.84 gcc_libinit.c:44:8: error: large atomic operation may incur significant performance penalty; the access size (4 bytes) exceeds the max lock-free size (0  bytes) [-Werror,-Watomic-alignment]

For these Go versions, we need to manually link to libatomic as arm/v6
does not support atomic intrinsics and neither the CGo, nor the C
toolchain automatically link to that library.


### update to go1.22.11 (fix CVE-2024-45341, CVE-2024-45336)

go1.22.11 (released 2025-01-16) includes security fixes to the crypto/x509 and
net/http packages, as well as bug fixes to the runtime. See the Go 1.22.11
milestone on our issue tracker for details.

- https://github.com/golang/go/issues?q=milestone%3AGo1.22.11+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.22.10...go1.22.11


Hello gophers,

We have just released Go versions 1.23.5 and 1.22.11, minor point releases.

These minor releases include 2 security fixes following the security policy:

- crypto/x509: usage of IPv6 zone IDs can bypass URI name constraints

  A certificate with a URI which has a IPv6 address with a zone ID may
  incorrectly satisfy a URI name constraint that applies to the certificate
  chain.

  Certificates containing URIs are not permitted in the web PKI, so this
  only affects users of private PKIs which make use of URIs.

  Thanks to Juho Forsén of Mattermost for reporting this issue.

  This is CVE-2024-45341 and Go issue https://go.dev/issue/71156.

- net/http: sensitive headers incorrectly sent after cross-domain redirect

  The HTTP client drops sensitive headers after following a cross-domain redirect.
  For example, a request to a.com/ containing an Authorization header which is
  redirected to b.com/ will not send that header to b.com.

  In the event that the client received a subsequent same-domain redirect, however,
  the sensitive headers would be restored. For example, a chain of redirects from
  a.com/, to b.com/1, and finally to b.com/2 would incorrectly send the Authorization
  header to b.com/2.

  Thanks to Kyle Seely for reporting this issue.

  This is CVE-2024-45336 and Go issue https://go.dev/issue/70530.


### update to go1.23.6


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

