### PR TITLE
secretservice: fix null derefence on locked collections

### DIFF
--- a/secretservice/secretservice.c
+++ b/secretservice/secretservice.c
@@ -83,6 +83,9 @@ GError *get(char *server, char **username, char **secret) {
 				}
 				g_free(value);
 				secretValue = secret_item_get_secret(l->data);
+				if (secretValue == NULL) {
+					continue;
+				}
 				if (secret != NULL) {
 					*secret = strdup(secret_value_get(secretValue, &length));
 					secret_value_unref(secretValue);


### PR DESCRIPTION
fixes #336

`secret_item_get_secret()` may return null if an item is locked or not loaded. While we set `SECRET_SEARCH_LOAD_SECRETS` and `SECRET_SEARCH_UNLOCK`, there may still be locked items, for example the user may refuse the unlock request.

So we still need to check if the secret data is NULL before we can try to reference it.
