### PR TITLE
[v0.9.0] osxkeychain: fix regressions on get and list

### DIFF
--- a/osxkeychain/osxkeychain.go
+++ b/osxkeychain/osxkeychain.go
@@ -117,8 +117,6 @@ func (h Osxkeychain) List() (map[string]string, error) {
 		default:
 			return nil, err
 		}
-	} else if len(res) == 0 {
-		return nil, credentials.NewErrCredentialsNotFound()
 	}
 
 	resp := make(map[string]string)

--- a/osxkeychain/osxkeychain.go
+++ b/osxkeychain/osxkeychain.go
@@ -129,14 +129,22 @@ func (h Osxkeychain) List() (map[string]string, error) {
 	return resp, nil
 }
 
+const (
+	// Hardcoded protocol types matching their Objective-C equivalents.
+	// https://developer.apple.com/documentation/security/ksecattrprotocolhttps?language=objc
+	kSecProtocolTypeHTTPS = "htps" // This is NOT a typo.
+	// https://developer.apple.com/documentation/security/ksecattrprotocolhttp?language=objc
+	kSecProtocolTypeHTTP = "http"
+)
+
 func splitServer(serverURL string, item keychain.Item) error {
 	u, err := registryurl.Parse(serverURL)
 	if err != nil {
 		return err
 	}
-	item.SetProtocol("https")
+	item.SetProtocol(kSecProtocolTypeHTTPS)
 	if u.Scheme == "http" {
-		item.SetProtocol("http")
+		item.SetProtocol(kSecProtocolTypeHTTP)
 	}
 	item.SetServer(u.Hostname())
 	if p := u.Port(); p != "" {


### PR DESCRIPTION
**- What I did**

**osxkeychain: list: do not error out when keychain is empty**

Commit https://github.com/docker/docker-credential-helpers/commit/4cdcdc29eb662eace1ec682ed7d70c99f4c00649 replaced the in-tree Objective-C code with github.com/keybase/go-keychain and inadvertently introduced a new failure mode on the `List` operation - it now fails when the keychain is empty.

Before:

```
$ ./bin/build/docker-credential-osxkeychain list
{}
```

After:

```
$ ./bin/build/docker-credential-osxkeychain list
credentials not found in native keychain
```

**osxkeychain: store: use Apple's proto consts**

Commit https://github.com/docker/docker-credential-helpers/commit/4cdcdc29eb662eace1ec682ed7d70c99f4c00649 swapped consts `kSecProtocolTypeHTTPS` and `kSecProtocolTypeHTTP` with plain-text "https" and "http" strings.

This is causing a regression where credentials stored with prior versions (< v0.9.0) can't be fetched anymore.

Unfortunately we can't just revert back to using Objective-C consts, as these are unsigned integers that need to be converted into `CFStringRef` and then passed to an helper like `keychain.CFStringToString`.

Although `keychain.CFStringToString` is exported, it takes a C type `C.CFStringRef` so it's not consumable from other packages due to Cgo restrictions:

> Cgo translates C types into equivalent unexported Go types. Because
> the translations are unexported, a Go package should not expose C
> types in its exported API: a C type used in one Go package is
> different from the same C type used in another.

We could alternatively copy `keychain.CFStringToString` into the `osxkeychain` package, but this commit takes a simpler approach: just hardcode the value of `kSecProtocolTypeHTTPS` and `kSecProtocolTypeHTTP` as strings. (These consts are very unlikely to ever change since it'd break all existing consumers.)

**This is NOT handling backward compatibility with v0.9.0, since it was released only 12hrs ago. So this fix won't work with credentials created with v0.9.0.**

**- How to verify it**

```
# Create credentials with an older version of docker-credential-osxkeychain

$ ~/.local/bin/docker-credential-osxkeychain version     
docker-credential-osxkeychain (github.com/docker/docker-credential-helpers) v0.8.2

$ echo '{"ServerURL":"https://index.docker.io/v1/","Username":"albinkerouanton006","Secret":"some valid token"}' | ~/.local/bin/docker-credential-osxkeychain store

# Then with these commits applied:

$ ./bin/build/docker-credential-osxkeychain list                                                                                                                   
{"/v1/":"albinkerouanton006"}

$ echo 'https://index.docker.io/v1/' | ./bin/build/docker-credential-osxkeychain get
{"ServerURL":"https://index.docker.io/v1/","Username":"albinkerouanton006","Secret":"some valid token"}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

