### PR TITLE
go.mod: retract v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/docker/docker-credential-helpers
 
 go 1.21
 
+retract v0.9.0 // osxkeychain: a regression caused backward-incompatibility with earlier versions
+
 require (
 	github.com/danieljoos/wincred v1.2.2
 	github.com/keybase/go-keychain v0.0.1


### PR DESCRIPTION
**- What I did**

Commit 4cdcdc2 introduced two regressions in the `osxkeychain` credential helper,  on `list` and `get` operations. These were addressed in:

- Commit c7514a0: osxkeychain: list: do not error out when keychain is empty
- Commit f4cdabf: osxkeychain: store: use Apple's proto consts
