### PR TITLE
go.mod: retract v0.9.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/docker/docker-credential-helpers
 
 go 1.21
 
-retract v0.9.0 // osxkeychain: a regression caused backward-incompatibility with earlier versions
+retract (
+	v0.9.1 // osxkeychain: a regression caused backward-incompatibility with earlier versions
+	v0.9.0 // osxkeychain: a regression caused backward-incompatibility with earlier versions
+)
 
 require (
 	github.com/danieljoos/wincred v1.2.2


### PR DESCRIPTION
**- What I did**

`osxkeychain` in v0.9.1 still doesn't list credentials as prior versionsdid. We're retracting this version too.