### PR TITLE
gha: add ubuntu 24.04, remove 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - macOS-15
           - macOS-14
           - macOS-13


### PR DESCRIPTION
Github is phasing out Ubuntu 20.04, and currently is doing brownouts; https://github.com/actions/runner-images/issues/11101


**- A picture of a cute animal (not mandatory but encouraged)**

