### PR TITLE
vendor: github.com/danieljoos/wincred v1.2.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ retract (
 )
 
 require (
-	github.com/danieljoos/wincred v1.2.2
+	github.com/danieljoos/wincred v1.2.3
 	github.com/keybase/go-keychain v0.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
-github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
@@ -8,8 +8,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/vendor/github.com/danieljoos/wincred/sys.go
+++ b/vendor/github.com/danieljoos/wincred/sys.go
@@ -5,6 +5,7 @@ package wincred
 
 import (
 	"reflect"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -33,10 +34,10 @@ type sysCREDENTIAL struct {
 	Comment            *uint16
 	LastWritten        windows.Filetime
 	CredentialBlobSize uint32
-	CredentialBlob     uintptr
+	CredentialBlob     *byte
 	Persist            uint32
 	AttributeCount     uint32
-	Attributes         uintptr
+	Attributes         *sysCREDENTIAL_ATTRIBUTE
 	TargetAlias        *uint16
 	UserName           *uint16
 }
@@ -46,7 +47,7 @@ type sysCREDENTIAL_ATTRIBUTE struct {
 	Keyword   *uint16
 	Flags     uint32
 	ValueSize uint32
-	Value     uintptr
+	Value     *byte
 }
 
 // https://docs.microsoft.com/en-us/windows/desktop/api/wincred/ns-wincred-_credentialw
@@ -93,6 +94,8 @@ func sysCredWrite(cred *Credential, typ sysCRED_TYPE) error {
 		uintptr(unsafe.Pointer(ncred)),
 		0,
 	)
+	// Make sure everything reachable from ncred stays alive through the call.
+	runtime.KeepAlive(ncred)
 	if ret == 0 {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/danieljoos/wincred v1.2.2
+# github.com/danieljoos/wincred v1.2.3
 ## explicit; go 1.18
 github.com/danieljoos/wincred
 # github.com/keybase/go-keychain v0.0.1


### PR DESCRIPTION
fix unsafe uintptr usage to be GC-safe on go1.25

full diff: https://github.com/danieljoos/wincred/compare/v1.2.2...v1.2.3


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

