### PR TITLE
Dockerfile: document build-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,28 @@
 # syntax=docker/dockerfile:1
 
+# GO_VERSION sets the version of the golang base image to use.
+# It must be a valid tag in the docker.io/library/golang image repository.
 ARG GO_VERSION=1.25.8
-ARG DEBIAN_VERSION=bookworm
 
+# BASE_DEBIAN_DISTRO sets the golang base image debian variant to use.
+# It must be a valid variant in the docker.io/library/golang image repository.
+ARG BASE_DEBIAN_DISTRO=bookworm
+
+# XX_VERSION sets the version of the xx utility to use.
+# It must be a valid tag in the docker.io/tonistiigi/xx image repository.
 ARG XX_VERSION=1.7.0
+
+# OSXCROSS_VERSION sets the MacOSX cross toolchain to use.
+# It must be a valid tag in the docker.io/crazymax/osxcross image repository.
 ARG OSXCROSS_VERSION=11.3-r8-debian
+
+# GOLANGCI_LINT_VERSION sets the version of the golangci-lint image to use.
+# It must be a valid tag in the docker.io/golangci/golangci-lint image repository.
 ARG GOLANGCI_LINT_VERSION=v2.8
 
+# PACKAGE sets the package name to print in the "--version" output.
+# It sets the "github.com/docker/docker-credential-helpers/credentials.Package
+# variable at compile time.
 ARG PACKAGE=github.com/docker/docker-credential-helpers
 
 # xx is a helper for cross-compilation
@@ -15,7 +31,7 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 # osxcross contains the MacOSX cross toolchain for xx
 FROM crazymax/osxcross:${OSXCROSS_VERSION} AS osxcross
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${DEBIAN_VERSION} AS gobase
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO} AS gobase
 COPY --from=xx / /
 RUN apt-get update && apt-get install -y --no-install-recommends clang dpkg-dev file git lld llvm make pkg-config rsync
 ENV GOFLAGS="-mod=vendor"

--- a/deb/Dockerfile
+++ b/deb/Dockerfile
@@ -1,10 +1,17 @@
 # syntax=docker/dockerfile:1
 
+# GO_VERSION sets the version of the golang base image to use.
+# It must be a valid tag in the docker.io/library/golang image repository.
 ARG GO_VERSION=1.25.8
+
+# BASE_DEBIAN_DISTRO sets the golang base image debian variant to use.
+# It must be a valid variant in the docker.io/library/golang image repository.
+ARG BASE_DEBIAN_DISTRO=bookworm
+
 ARG DISTRO=ubuntu
 ARG SUITE=jammy
 
-FROM golang:${GO_VERSION}-bookworm AS golang
+FROM golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO} AS gobase
 
 FROM ${DISTRO}:${SUITE}
 RUN apt-get update && apt-get install -yy debhelper dh-make libsecret-1-dev
@@ -15,7 +22,7 @@ ENV GOPROXY=https://proxy.golang.org|direct
 ENV GO111MODULE=off
 ENV GOPATH=/build
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
-COPY --from=golang /usr/local/go /usr/local/go
+COPY --from=gobase /usr/local/go /usr/local/go
 
 COPY Makefile .
 COPY credentials credentials


### PR DESCRIPTION
```bash
docker buildx build --quiet --call=outline .

BUILD ARG            VALUE                                         DESCRIPTION
GO_VERSION           1.25.7                                        sets the version of the golang base image to use.
BASE_DEBIAN_DISTRO   bookworm                                      sets the golang base image debian variant to use.
XX_VERSION           1.7.0                                         sets the version of the xx utility to use.
OSXCROSS_VERSION     11.3-r8-debian                                sets the MacOSX cross toolchain to use.
PACKAGE              github.com/docker/docker-credential-helpers   sets the package name to print in the "--version" output.
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

