### PR TITLE
Dockerfile: update golangci-lint to v2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG OSXCROSS_VERSION=11.3-r8-debian
 
 # GOLANGCI_LINT_VERSION sets the version of the golangci-lint image to use.
 # It must be a valid tag in the docker.io/golangci/golangci-lint image repository.
-ARG GOLANGCI_LINT_VERSION=v2.8
+ARG GOLANGCI_LINT_VERSION=v2.11
 
 # PACKAGE sets the package name to print in the "--version" output.
 # It sets the "github.com/docker/docker-credential-helpers/credentials.Package


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/docker-credential-helpers/pull/412

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

