### PR TITLE
wincred: inline label, and append to existing

### DIFF
--- a/wincred/wincred.go
+++ b/wincred/wincred.go
@@ -16,12 +16,14 @@ type Wincred struct{}
 
 // Add adds new credentials to the windows credentials manager.
 func (h Wincred) Add(creds *credentials.Credentials) error {
-	credsLabels := []byte(credentials.CredsLabel)
 	g := winc.NewGenericCredential(creds.ServerURL)
 	g.UserName = creds.Username
 	g.CredentialBlob = []byte(creds.Secret)
 	g.Persist = winc.PersistLocalMachine
-	g.Attributes = []winc.CredentialAttribute{{Keyword: "label", Value: credsLabels}}
+	g.Attributes = append(g.Attributes, winc.CredentialAttribute{
+		Keyword: "label",
+		Value:   []byte(credentials.CredsLabel),
+	})
 
 	return g.Write()
 }


### PR DESCRIPTION
The code assumed that Attributes was always empty, so unconditionally replaced the attributes. Let's not assume that's the case (even if it is currently). Also inline the label for readability; we could optimize the byte-slice by making a package level variable, to avoid allocating, but that's probably not worth the optimzation.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

